### PR TITLE
Remove allAvailable query parameter, make since=0 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ Note that these data should comply with the requirements specified in SQLAlchemy
 To visualize the API, open your browser to here (the location and port may vary according to the script parameters or the values in `config/config.json`):
 
 ```
-http://localhost:8080/ui/
+http://localhost:8080/v2/protocol/ui
 ```
 
 Your OpenAPI definition lives here:
 
 ```
-http://localhost:8080/openapi.json
+http://localhost:8080/v2/protocol/openapi.json
 ```
 ### Running with Docker
 To run the server on a Docker container, run:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.2
 
 info:
   title: Fleet v2 HTTP API
-  version: 2.0.6
+  version: 2.1.0
   description: HTTP-based API for Fleet Protocol v2 serving for communication between the External Server and the end users.
   contact:
     email: jiri.strouhal@bringauto.com
@@ -63,7 +63,7 @@ paths:
         - $ref: '#/components/parameters/kcSessionState'
         - $ref: '#/components/parameters/kcIss'
         - $ref: '#/components/parameters/kcCode'
-      
+
   /token_refresh:
     get:
       x-openapi-router-controller: fleetv2_http_api.impl.controllers
@@ -185,7 +185,6 @@ paths:
           description: The statuses cannot be displayed due to internal server error.
 
       parameters:
-        - $ref: '#/components/parameters/All'
         - $ref: '#/components/parameters/Since'
         - $ref: '#/components/parameters/Wait'
 
@@ -250,7 +249,6 @@ paths:
           description: The commands cannot be displayed due to internal server error.
 
       parameters:
-        - $ref: '#/components/parameters/All'
         - $ref: '#/components/parameters/Since'
         - $ref: '#/components/parameters/Wait'
 
@@ -299,7 +297,7 @@ components:
     oAuth2AuthCode:
       type: oauth2
       description: oAuth2 authorization
-      flows: 
+      flows:
         authorizationCode:
           authorizationUrl: https://keycloak.bringauto.com/realms/bringauto/protocol/openid-connect/auth
           tokenUrl: https://keycloak.bringauto.com/realms/bringauto/protocol/openid-connect/token
@@ -308,15 +306,6 @@ components:
 
 
   parameters:
-    All:
-      name: all_available
-      description: If set, the method returns a complete history of statuses/commands.
-      in: query
-      schema:
-        type: boolean
-        nullable: true
-      example: False
-
     Since:
       name: since
       description: A Unix timestamp; if specified, the method returns all messages inclusivelly newer than the specified timestamp \
@@ -325,6 +314,7 @@ components:
       schema:
         type: integer
         nullable: true
+        default: 0
       example: 1699262836
 
     ModuleId:
@@ -344,6 +334,7 @@ components:
       schema:
         type: boolean
         nullable: true
+        default: false
       example: True
 
     CarName:

--- a/server/database/database_controller.py
+++ b/server/database/database_controller.py
@@ -166,8 +166,7 @@ def list_messages(
     company_name: str,
     car_name: str,
     message_type: str,
-    all_available: Optional[bool] = None,
-    since: Optional[int] = None
+    since: int = 0
     ) -> List[Message_DB]:  # noqa:
 
     """Return a list of messages of the given type, optionally filtered by the given parameters.
@@ -181,28 +180,11 @@ def list_messages(
     with Session(get_connection_source()) as session:
         table = MessageBase.__table__
         selection = select(MessageBase).where(table.c.message_type == message_type)
-        if all_available is True:
-            selection = selection.where(and_(
-                table.c.company_name == company_name,
-                table.c.car_name == car_name
-            ))
-        elif since is not None:
-            selection = selection.where(and_(
-                table.c.company_name == company_name,
-                table.c.car_name == car_name,
-                table.c.timestamp >= since
-            ))
-        else:
-            # return newest message
-            extreme_func = func.max
-            extreme_value = session.query(extreme_func(table.c.timestamp)).\
-                where(
-                    table.c.company_name == company_name,
-                    table.c.car_name == car_name,
-                    table.c.message_type == message_type
-                ).scalar()
-            selection = selection.where(table.c.timestamp == extreme_value)
-
+        selection = selection.where(and_(
+            table.c.company_name == company_name,
+            table.c.car_name == car_name,
+            table.c.timestamp >= since
+        ))
         result = session.execute(selection)
         for row in result:
             base: MessageBase = row[0]

--- a/server/database/tests/test_database_controller.py
+++ b/server/database/tests/test_database_controller.py
@@ -137,7 +137,6 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
             company_name="company1",
             car_name="car1",
             message_type=MessageType.STATUS_TYPE,
-            all_available=True
         )
         self.assertEqual(len(messages), 2)
         self.assertEqual(messages[0].timestamp, 1)
@@ -188,13 +187,7 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
             )
         )
         remove_old_messages(current_timestamp=MessageBase.data_retention_period_ms + 50)
-        self.assertEqual(
-            len(list_messages(
-                "test_company", "test_car", MessageType.STATUS_TYPE, all_available=""
-            ))
-            , 0
-        )
-
+        self.assertEqual(len(list_messages("test_company", "test_car", MessageType.STATUS_TYPE)), 0)
         warnings = cleanup_device_commands_and_warn_before_future_commands(
             current_timestamp=MessageBase.data_retention_period_ms + 55,
             company_name="test_company",
@@ -208,18 +201,16 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
             company_name="test_company",
             car_name="test_car",
             message_type=MessageType.COMMAND_TYPE,
-            all_available=""
         )
         self.assertEqual(len(messages), 0)
 
     @patch("database.time._time_in_ms")
-    def test_remove_old_messages(self, mock_time_in_ms:Mock):
+    def test_remove_old_messages(self, mock_time_in_ms: Mock):
         device_id = DeviceId(module_id=45, type=2, role="role1", name="device1")
         sdevice_id = serialized_device_id(device_id)
         message1 = Message_DB(
             timestamp=0,
             serialized_device_id=sdevice_id,
-
             module_id=device_id.module_id,
             device_type=device_id.type,
             device_role=device_id.role,
@@ -254,7 +245,6 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
             company_name="company1",
             car_name="car1",
             message_type=MessageType.STATUS_TYPE,
-            all_available=""
         )
         self.assertEqual(len(messages), 1)
 
@@ -321,10 +311,10 @@ class Test_Send_And_Read_Message(unittest.TestCase):
         mock_time_in_ms.return_value = 150
         send_messages_to_database("test_company", "test_car", message_2)
         # read all statuses
-        read_messages = list_messages("test_company", "test_car", MessageType.STATUS_TYPE, all_available=True)
+        read_messages = list_messages("test_company", "test_car", MessageType.STATUS_TYPE)
         self.assertEqual(len(read_messages), 2)
         # read only the last status
-        read_messages = list_messages("test_company", "test_car", MessageType.STATUS_TYPE)
+        read_messages = list_messages("test_company", "test_car", MessageType.STATUS_TYPE, since=150)
         self.assertEqual(len(read_messages), 1)
         # read only statuses after timestamp 120
         read_messages = list_messages("test_company", "test_car", MessageType.STATUS_TYPE, since=120)

--- a/server/fleetv2_http_api/controllers/device_controller.py
+++ b/server/fleetv2_http_api/controllers/device_controller.py
@@ -7,7 +7,7 @@ from fleetv2_http_api.models.message import Message  # noqa: E501
 from fleetv2_http_api import util
 
 
-def list_commands(company_name, car_name, all_available=None, since=None, wait=None):  # noqa: E501
+def list_commands(company_name, car_name, since=None, wait=None):  # noqa: E501
     """list_commands
 
     Returns list of the Device Commands. # noqa: E501
@@ -16,8 +16,6 @@ def list_commands(company_name, car_name, all_available=None, since=None, wait=N
     :type company_name: str
     :param car_name: Name of the Car, following a pattern ^[0-9a-z_]+$.
     :type car_name: str
-    :param all_available: If set, the method returns a complete history of statuses/commands.
-    :type all_available: bool
     :param since: A Unix timestamp; if specified, the method returns all messages inclusivelly newer than the specified timestamp \\ (i.e., messages with timestamp greater than or equal to the &#39;since&#39; timestamp)
     :type since: int
     :param wait: An empty parameter. If specified, the method waits for predefined period of time, until some data to be sent in response are available.
@@ -28,7 +26,7 @@ def list_commands(company_name, car_name, all_available=None, since=None, wait=N
     return 'do some magic!'
 
 
-def list_statuses(company_name, car_name, all_available=None, since=None, wait=None):  # noqa: E501
+def list_statuses(company_name, car_name, since=None, wait=None):  # noqa: E501
     """list_statuses
 
     It returns list of the Device Statuses. # noqa: E501
@@ -37,8 +35,6 @@ def list_statuses(company_name, car_name, all_available=None, since=None, wait=N
     :type company_name: str
     :param car_name: Name of the Car, following a pattern ^[0-9a-z_]+$.
     :type car_name: str
-    :param all_available: If set, the method returns a complete history of statuses/commands.
-    :type all_available: bool
     :param since: A Unix timestamp; if specified, the method returns all messages inclusivelly newer than the specified timestamp \\ (i.e., messages with timestamp greater than or equal to the &#39;since&#39; timestamp)
     :type since: int
     :param wait: An empty parameter. If specified, the method waits for predefined period of time, until some data to be sent in response are available.

--- a/server/fleetv2_http_api/impl/controllers.py
+++ b/server/fleetv2_http_api/impl/controllers.py
@@ -187,9 +187,8 @@ def available_devices(
 def list_commands(
     company_name: str,
     car_name: str,
-    all_available: Optional[bool] = None,
-    since: Optional[int] = None,
-    wait: Optional[bool] = None
+    since: int = 0,
+    wait: bool = False
     ) -> Tuple[List[Message], int]:  # noqa: E501
 
     """list_commands
@@ -200,8 +199,6 @@ def list_commands(
     :type company_name: str
     :param car_name: Name of the Car, following a pattern ^[0-9a-z_]+$.
     :type car_name: str
-    :param all_available: If set, the method returns a complete history of statuses/commands.
-    :type all_available: bool
     :param since: A Unix timestamp; if specified, the method returns all messages inclusivelly newer than the specified timestamp \\ (i.e., messages with timestamp greater than or equal to the &#39;since&#39; timestamp)
     :type since: int
     :param wait: An empty parameter. If specified, the method waits for predefined period of time, until some data to be sent in response are available.
@@ -214,7 +211,7 @@ def list_commands(
 
     company_and_car_name = f"Company='{company_name}', car='{car_name}'"
 
-    db_commands = _list_messages(company_name,car_name,MessageType.COMMAND_TYPE,all_available,since)
+    db_commands = _list_messages(company_name, car_name, MessageType.COMMAND_TYPE, since)
     if db_commands or not wait:
         msg, code = _check_car_availability(company_name, car_name)
         if code == 200:
@@ -239,9 +236,8 @@ def list_commands(
 def list_statuses(
     company_name: str,
     car_name: str,
-    all_available: Optional[bool] = None,
-    since: Optional[int] = None,
-    wait: Optional[bool] = None
+    since: int = 0,
+    wait: bool = False
     ) -> Tuple[List[Message], int]:  # noqa: E501
 
     """list_statuses
@@ -252,8 +248,6 @@ def list_statuses(
     :type company_name: str
     :param car_name: Name of the Car, following a pattern ^[0-9a-z_]+$.
     :type car_name: str
-    :param all_available: If set, the method returns a complete history of statuses/commands.
-    :type all_available: bool
     :param since: A Unix timestamp; if specified, the method returns all messages inclusivelly newer than the specified timestamp \\ (i.e., messages with timestamp greater than or equal to the &#39;since&#39; timestamp)
     :type since: int
     :param wait: An empty parameter. If specified, the method waits for predefined period of time, until some data to be sent in response are available.
@@ -266,7 +260,7 @@ def list_statuses(
 
     company_and_car_name = f"Company='{company_name}', car='{car_name}'"
 
-    db_statuses = _list_messages(company_name, car_name, MessageType.STATUS_TYPE, all_available, since)
+    db_statuses = _list_messages(company_name, car_name, MessageType.STATUS_TYPE, since)
     if db_statuses:
         statuses = [_message_from_db(m) for m in db_statuses]
         return _log_and_respond(statuses, 200, f"Returning statuses for available car ({company_and_car_name}).")

--- a/server/fleetv2_http_api/impl/tests/test_controllers.py
+++ b/server/fleetv2_http_api/impl/tests/test_controllers.py
@@ -146,7 +146,7 @@ class Test_Sending_Status(unittest.TestCase):
 
     def test_status_sent_to_and_retrieved_from_database_has_unchanged_attributes(self):
         send_statuses("test_company", "test_car", body=[self.status_example])
-        status:Message = list_statuses("test_company", "test_car")[0][0]
+        status: Message = list_statuses("test_company", "test_car")[0][0]
         self.assertEqual(status.device_id.name, self.status_example.device_id.name)
 
 
@@ -378,9 +378,9 @@ class Test_Options_For_Listing_Multiple_Statuses(unittest.TestCase):
         mock_time_in_ms.return_value = 37
         send_statuses("company", "car", body=[message_3])
 
-    def test_by_default_only_the_newest_status_is_returned(self):
+    def test_by_default_all_statuses_are_returned(self):
         statuses, _ = list_statuses("company", "car")
-        self.assertEqual(len(statuses), 1)
+        self.assertEqual(len(statuses), 3)
         self.assertEqual(statuses[-1].timestamp, 37)
 
     def test_since_parameter_equal_to_newest_status_timestamp_yields_the_newest_status(self):
@@ -396,14 +396,6 @@ class Test_Options_For_Listing_Multiple_Statuses(unittest.TestCase):
         statuses, _ = list_statuses("company", "car", since=20)
         self.assertEqual(statuses[0].timestamp, 20)
         self.assertEqual(statuses[1].timestamp, 37)
-
-    def test_if_all_is_specified_all_statuses_are_returned(self):
-        # any value passed as 'all' attribute makes the list_statuses to return all the statuses
-        statuses, _ = list_statuses("company", "car", all_available=True)
-        self.assertEqual(len(statuses), 3)
-        self.assertEqual(statuses[0].timestamp, 10)
-        self.assertEqual(statuses[1].timestamp, 20)
-        self.assertEqual(statuses[2].timestamp, 37)
 
 
 class Test_Options_For_Listing_Multiple_Commands(unittest.TestCase):
@@ -429,17 +421,17 @@ class Test_Options_For_Listing_Multiple_Commands(unittest.TestCase):
         mock_time_in_ms.return_value = 45
         send_commands("company", "car", [command_3])
 
-    def test_by_default_only_the_newest_command_is_returned(self):
+    def test_by_default_all_commands_are_returned(self):
         commands, code = list_commands("company", "car")
-        self.assertEqual(len(commands), 1)
+        self.assertEqual(len(commands), 3)
         self.assertEqual(commands[-1].timestamp, 45)
 
-    def test_since_parameter_equal_to_newest_command_timestamp_yields_the_oldest_command(self):
+    def test_since_parameter_equal_to_newest_command_timestamp_yields_the_newest_command(self):
         commands, code = list_commands("company", "car", since=45)
         self.assertEqual(len(commands), 1)
         self.assertEqual(commands[0].timestamp, 45)
 
-    def test_since_parameter_smaller_than_newest_command_timestamp_yields_empty_command_list(self):
+    def test_since_parameter_greater_than_newest_command_timestamp_yields_empty_command_list(self):
         commands, code = list_commands("company", "car", since=46)
         self.assertEqual(len(commands), 0)
 
@@ -448,13 +440,6 @@ class Test_Options_For_Listing_Multiple_Commands(unittest.TestCase):
         self.assertEqual(len(commands), 2)
         self.assertEqual(commands[0].timestamp, 30)
         self.assertEqual(commands[1].timestamp, 45)
-
-    def test_if_all_is_specified_all_commands_are_returned(self):
-        commands, code = list_commands("company", "car",  all_available=True)
-        self.assertEqual(len(commands), 3)
-        self.assertEqual(commands[0].timestamp, 20)
-        self.assertEqual(commands[1].timestamp, 30)
-        self.assertEqual(commands[2].timestamp, 45)
 
 
 class Test_Cleaning_Up_Commands(unittest.TestCase):
@@ -481,22 +466,22 @@ class Test_Cleaning_Up_Commands(unittest.TestCase):
         mock_time_in_ms.return_value = 20
         send_commands("company", "car", [command_2])
 
-        self.assertEqual(len(list_statuses("company", "car", all_available=True)[0]), 1)
-        self.assertEqual(len(list_commands("company", "car", all_available=True)[0]), 2)
+        self.assertEqual(len(list_statuses("company", "car", since=0)[0]), 1)
+        self.assertEqual(len(list_commands("company", "car", since=0)[0]), 2)
 
         mock_time_in_ms.return_value = self.DATA_RETENTION_PERIOD+20
         remove_old_messages(mock_time_in_ms.return_value)
 
-        self.assertEqual(len(list_statuses("company", "car", all_available=True)[0]), 0)
-        self.assertEqual(len(list_commands("company", "car", all_available=True)[0]), 0)
+        self.assertEqual(len(list_statuses("company", "car", since=0)[0]), 0)
+        self.assertEqual(len(list_commands("company", "car", since=0)[0]), 0)
 
         mock_time_in_ms.return_value += 5
 
         # the following status is considered to be the FIRST status for given device and after sending it,
         # all commands previously sent to this device have to be removed
         send_statuses("company", "car", [status])
-        self.assertEqual(len(list_statuses("company", "car", all_available=True)[0]), 1)
-        self.assertEqual(len(list_commands("company", "car", all_available=True)[0]), 0)
+        self.assertEqual(len(list_statuses("company", "car", since=0)[0]), 1)
+        self.assertEqual(len(list_commands("company", "car", since=0)[0]), 0)
 
     @patch('database.time._time_in_ms')
     def test_cleaning_up_command_with_newer_timestamp_relative_to_the_first_status_raises_warning(self, mock_time_in_ms:Mock):
@@ -521,10 +506,10 @@ class Test_Cleaning_Up_Commands(unittest.TestCase):
 
         remove_old_messages(self.DATA_RETENTION_PERIOD + 10)
 
-        self.assertEqual(len(list_statuses("company", "car", all_available=True)[0]), 0)
+        self.assertEqual(len(list_statuses("company", "car", since=0)[0]), 0)
         # The device is considered to be disconnected and all commands sent to it are then
         # considered to be removed.
-        self.assertEqual(len(list_commands("company", "car", all_available=True)[0]), 0)
+        self.assertEqual(len(list_commands("company", "car", since=0)[0]), 0)
 
         self.assertEqual(
             available_devices("company", "car"),
@@ -534,8 +519,8 @@ class Test_Cleaning_Up_Commands(unittest.TestCase):
 
         mock_time_in_ms.return_value = self.DATA_RETENTION_PERIOD + 50
         warnings, code = send_statuses("company", "car", [new_first_status])
-        self.assertEqual(len(list_statuses("company", "car", all_available=True)[0]), 1)
-        self.assertEqual(len(list_commands("company", "car", all_available=True)[0]), 0)
+        self.assertEqual(len(list_statuses("company", "car", since=0)[0]), 1)
+        self.assertEqual(len(list_commands("company", "car", since=0)[0]), 0)
 
         assert(type(warnings) is str)
         for warning in future_command_warning(

--- a/server/fleetv2_http_api/openapi/openapi.yaml
+++ b/server/fleetv2_http_api/openapi/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: GPLv3
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: Fleet v2 HTTP API
-  version: 2.0.6
+  version: 2.1.0
 servers:
 - url: /v2/protocol
 security:
@@ -123,16 +123,6 @@ paths:
           pattern: "^[a-z0-9_]+$"
           type: string
         style: simple
-      - description: "If set, the method returns a complete history of statuses/commands."
-        example: false
-        explode: true
-        in: query
-        name: all_available
-        required: false
-        schema:
-          nullable: true
-          type: boolean
-        style: form
       - description: "A Unix timestamp; if specified, the method returns all messages\
           \ inclusivelly newer than the specified timestamp \\ (i.e., messages with\
           \ timestamp greater than or equal to the 'since' timestamp)"
@@ -142,6 +132,7 @@ paths:
         name: since
         required: false
         schema:
+          default: 0
           nullable: true
           type: integer
         style: form
@@ -153,6 +144,7 @@ paths:
         name: wait
         required: false
         schema:
+          default: false
           nullable: true
           type: boolean
         style: form
@@ -290,16 +282,6 @@ paths:
           pattern: "^[a-z0-9_]+$"
           type: string
         style: simple
-      - description: "If set, the method returns a complete history of statuses/commands."
-        example: false
-        explode: true
-        in: query
-        name: all_available
-        required: false
-        schema:
-          nullable: true
-          type: boolean
-        style: form
       - description: "A Unix timestamp; if specified, the method returns all messages\
           \ inclusivelly newer than the specified timestamp \\ (i.e., messages with\
           \ timestamp greater than or equal to the 'since' timestamp)"
@@ -309,6 +291,7 @@ paths:
         name: since
         required: false
         schema:
+          default: 0
           nullable: true
           type: integer
         style: form
@@ -320,6 +303,7 @@ paths:
         name: wait
         required: false
         schema:
+          default: false
           nullable: true
           type: boolean
         style: form
@@ -500,17 +484,6 @@ paths:
       x-openapi-router-controller: fleetv2_http_api.impl.controllers
 components:
   parameters:
-    All:
-      description: "If set, the method returns a complete history of statuses/commands."
-      example: false
-      explode: true
-      in: query
-      name: all_available
-      required: false
-      schema:
-        nullable: true
-        type: boolean
-      style: form
     Since:
       description: "A Unix timestamp; if specified, the method returns all messages\
         \ inclusivelly newer than the specified timestamp \\ (i.e., messages with\
@@ -521,6 +494,7 @@ components:
       name: since
       required: false
       schema:
+        default: 0
         nullable: true
         type: integer
       style: form
@@ -545,6 +519,7 @@ components:
       name: wait
       required: false
       schema:
+        default: false
         nullable: true
         type: boolean
       style: form


### PR DESCRIPTION
'allAvailable' query parameter was removed from GET methods for /status and /command endpoints. 
'since' parameter is now set to 0 by default. 

There was incorrect URI to the Swagger UI and the openapi.json in the README. This has been fixed. 