### PR TITLE
Fix bug in wait mechanism for available cars

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.2
 
 info:
   title: Fleet v2 HTTP API
-  version: 2.2.2
+  version: 2.2.3
   description: HTTP-based API for Fleet Protocol v2 serving for communication between the External Server and the end users.
   contact:
     email: jiri.strouhal@bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "server"
-version = "2.2.2"
+version = "2.2.3"
 
 
 [tool.setuptools.packages.find]

--- a/server/fleetv2_http_api/impl/controllers.py
+++ b/server/fleetv2_http_api/impl/controllers.py
@@ -161,11 +161,14 @@ def available_cars(wait: bool = False) -> tuple[list[Car], int]:
         for car_name in device_dict[company_name]:
             cars.append(Car(company_name, car_name))
     if cars:
-        return _log_and_respond(cars, 200, "listing available cars.")
+        n = sum([len(device_dict[company_name]) for company_name in device_dict])
+        return _log_and_respond(cars, 200, f"Found {n} available cars for {len(device_dict)} companies.")
     else:
-        awaited_cars: list[Car] = _car_wait_manager.wait_and_get_reponse()
+        awaited_cars: list[Any] = _car_wait_manager.wait_and_get_reponse()
         if awaited_cars:
-            return _log_and_respond(awaited_cars, 200, "listing available cars.")
+            n = len(awaited_cars)
+            response = _log_and_respond(awaited_cars, 200, f"Returning {n} new available cars.")
+            return response
         else:
             return _log_and_respond([], 200, "No cars were found. Returning empty list.")
 

--- a/server/fleetv2_http_api/impl/controllers.py
+++ b/server/fleetv2_http_api/impl/controllers.py
@@ -160,7 +160,7 @@ def available_cars(wait: bool = False) -> tuple[list[Car], int]:
     for company_name in device_dict:
         for car_name in device_dict[company_name]:
             cars.append(Car(company_name, car_name))
-    if cars:
+    if cars or not wait:
         n = sum([len(device_dict[company_name]) for company_name in device_dict])
         return _log_and_respond(cars, 200, f"Found {n} available cars for {len(device_dict)} companies.")
     else:

--- a/server/fleetv2_http_api/impl/message_wait.py
+++ b/server/fleetv2_http_api/impl/message_wait.py
@@ -26,10 +26,12 @@ class MessageWaitObjManager:
     def new_wait_obj(self, company_name: str, car_name: str) -> MessageWaitObj:
         """Create a new wait object and adds it to the wait queue for given company and car."""
         wait_obj = MessageWaitObj(company_name, car_name, self._timeout_ms)
+
         if not company_name in self._wait_dict:
             self._wait_dict[company_name] = dict()
-            if not car_name in self._wait_dict[company_name]:
-                self._wait_dict[company_name][car_name] = list()
+        if not car_name in self._wait_dict[company_name]:
+            self._wait_dict[company_name][car_name] = list()
+
         self._wait_dict[company_name][car_name].append(wait_obj)
         return wait_obj
 

--- a/server/fleetv2_http_api/openapi/openapi.yaml
+++ b/server/fleetv2_http_api/openapi/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: GPLv3
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: Fleet v2 HTTP API
-  version: 2.2.2
+  version: 2.2.3
 servers:
 - url: /v2/protocol
 security:


### PR DESCRIPTION
Key for a company in MessageWaitObjManager was erroneously deleted when a new car became available. Fixed, and added unit test.

The log message for available/no available cars now contains the number of cars and companies.