### PR TITLE
Baip 237/filtering cars by connection time

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.2
 
 info:
   title: Fleet v2 HTTP API
-  version: 2.2.3
+  version: 2.3.0
   description: HTTP-based API for Fleet Protocol v2 serving for communication between the External Server and the end users.
   contact:
     email: jiri.strouhal@bringauto.com

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -112,6 +112,7 @@ paths:
 
       parameters:
         - $ref: '#/components/parameters/Wait'
+        - $ref: '#/components/parameters/Since'
 
   /available-devices/{company_name}/{car_name}:
     get:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "server"
-version = "2.2.3"
+version = "2.3.0"
 
 
 [tool.setuptools.packages.find]

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -5,7 +5,7 @@ import logging
 from apscheduler.schedulers.background import BackgroundScheduler  # type: ignore
 
 from database.database_controller import remove_old_messages, set_message_retention_period  # type: ignore
-from database.device_ids import clear_device_ids  # type: ignore
+from database.device_ids import clear_connected_cars  # type: ignore
 from database.connection import set_db_connection  # type: ignore
 from database.time import timestamp  # type: ignore
 from fleetv2_http_api.__main__ import main as run_server  # type: ignore
@@ -24,7 +24,7 @@ def _clean_up_messages() -> None:
 
 def _connect_to_database(vals:script_args.ScriptArgs) -> None:
     """Clear previously stored available devices and connect to the database."""
-    clear_device_ids()
+    clear_connected_cars()
     set_db_connection(
         dblocation = vals.argvals["location"] + ":" + str(vals.argvals["port"]),
         username = vals.argvals["username"],

--- a/server/app.py
+++ b/server/app.py
@@ -20,7 +20,7 @@ from fleetv2_http_api.encoder import JSONEncoder  # type: ignore
 from database.security import _AdminBase as _AdminBase  # type: ignore
 
 # Keep the following import to make all the tables be created by the get_test_app function
-from database.device_ids import clear_device_ids as _clear_device_ids  # type: ignore
+from database.device_ids import clear_connected_cars as _clear_device_ids  # type: ignore
 
 
 def get_app() -> _connexion.FlaskApp:

--- a/server/database/device_ids.py
+++ b/server/database/device_ids.py
@@ -1,4 +1,6 @@
 import sys
+import dataclasses
+from collections import defaultdict
 
 sys.path.append("source")
 
@@ -7,76 +9,120 @@ from copy import deepcopy
 from fleetv2_http_api.models.device_id import DeviceId  # type: ignore
 
 
-Device_Ids = dict[str, dict[str, dict[int, dict[str, DeviceId]]]]
+@dataclasses.dataclass(frozen=True)
+class ConnectedModule:
+    id: int
+    device_ids: list[DeviceId] = dataclasses.field(default_factory=list)
+
+    @property
+    def sdevice_ids(self) -> list[str]:
+        return [serialized_device_id(device_id) for device_id in self.device_ids]
+
+    def add_device(self, device_id: DeviceId) -> bool:
+        """Add a device id to the device_ids list.
+
+        Returns True if the device id was stored, False otherwise.
+        """
+        if device_id not in self.device_ids:
+            self.device_ids.append(device_id)
+            return True
+        return False
+
+    def remove_device(self, device_id: DeviceId) -> bool:
+        """Remove a device id from the device_ids list.
+
+        Returns True if the device id was removed, False otherwise.
+        """
+        if device_id in self.device_ids:
+            self.device_ids.remove(device_id)
+            return True
+        return False
 
 
-_device_ids: Device_Ids = {}
+@dataclasses.dataclass(frozen=True)
+class ConnectedCar:
+    company_name: str
+    car_name: str
+    timestamp: int
+    modules: dict[int, ConnectedModule] = dataclasses.field(default_factory=dict)
+
+    def add_device(self, device_id: DeviceId) -> bool:
+        """Add a device id to the device_ids dictionary.
+
+        Returns True if the device id was stored, False otherwise.
+        """
+        assert isinstance(device_id, DeviceId)
+        if not device_id.module_id in self.modules:
+            self.modules[device_id.module_id] = ConnectedModule(id=device_id.module_id)
+        return self.modules[device_id.module_id].add_device(device_id)
+
+    def is_connected(self, device_id: DeviceId) -> bool:
+        """Check if a device id is connected to this car."""
+        assert isinstance(device_id, DeviceId)
+        return device_id.module_id in self.modules and device_id in self.modules[device_id.module_id].device_ids
+
+    def remove_device(self, device_id: DeviceId) -> bool:
+        """Remove a device id from its module dict in the device_ids dictionary.
+
+        Returns True if the device id was removed, False otherwise.
+        """
+        assert isinstance(device_id, DeviceId)
+        if device_id.module_id in self.modules:
+            self.modules[device_id.module_id].remove_device(device_id)
+            if not self.modules[device_id.module_id].device_ids:
+                self.modules.pop(device_id.module_id)
+            return True
+        return False
 
 
-def device_ids() -> Device_Ids:
+_connected_cars: dict[str, dict[str, ConnectedCar]] = defaultdict(dict)
+
+
+def connected_cars() -> dict[str, dict[str, ConnectedCar]]:
     """Return a deep copy of the device_ids dictionary.""" ""
-    return deepcopy(_device_ids)
+    return deepcopy(_connected_cars)
 
 
-def clear_device_ids() -> None:
+def clear_connected_cars() -> None:
     """Clear the whole device_ids dictionary.""" ""
-    _device_ids.clear()
+    _connected_cars.clear()
 
 
-def remove_device_id(company_name: str, car_name: str, device_id: DeviceId | str) -> None:
+def remove_connected_device(company_name: str, car_name: str, device_id: DeviceId) -> None:
     """Remove a device id from its module dict in the device_ids dictionary."""
-    if isinstance(device_id, DeviceId):
-        sdevice_id = serialized_device_id(device_id)
-        module_id = device_id.module_id
-    else:
-        sdevice_id = device_id
-        module_id = int(device_id.split("_")[0])
-    _device_ids[company_name][car_name][module_id].pop(sdevice_id)
+    assert isinstance(device_id, DeviceId)
+    _connected_cars[company_name][car_name].remove_device(device_id)
 
 
 def clean_up_disconnected_cars_and_modules() -> None:
     """Remove empty modules, cars and companies from the device_ids dictionary."""
-    for company_name in _device_ids:
-        for car_name in _device_ids[company_name]:
-            empty_modules = [
-                module_id
-                for module_id in _device_ids[company_name][car_name].keys()
-                if not _device_ids[company_name][car_name][module_id]
-            ]
-            for module_id in empty_modules:
-                _device_ids[company_name][car_name].pop(module_id)
+    for company in _connected_cars:
+        for car in _connected_cars[company]:
+            empty_modules: list[ConnectedModule] = []
+            for module in _connected_cars[company][car].modules.values():
+                if not module.device_ids:
+                    empty_modules.append(module)
+            for module in empty_modules:
+                _connected_cars[company][car].modules.pop(module.id)
 
-        cars_without_modules = [
-            car for car in _device_ids[company_name].keys() if not _device_ids[company_name][car]
-        ]
+        cars_without_modules = [car for car in _connected_cars[company].keys() if not _connected_cars[company][car].modules]
         for car in cars_without_modules:
-            _device_ids[company_name].pop(car)
+            _connected_cars[company].pop(car)
 
-    companies_without_cars = [company for company in _device_ids.keys() if not _device_ids[company]]
+    companies_without_cars = [company for company in _connected_cars.keys() if not _connected_cars[company]]
     for company in companies_without_cars:
-        _device_ids.pop(company)
+        _connected_cars.pop(company)
 
 
-def store_device_id_if_new(company_name: str, car_name: str, device_id: DeviceId) -> bool:
-    """
-    Add a device id to the device_ids dictionary if it is not already there.
+def store_connected_device_if_new(company_name: str, car_name: str, device_id: DeviceId) -> bool:
+    """Add a device id to the device_ids dictionary if it is not already there.
+
     Returns True if the device id was stored, False otherwise.
     """
-    sdevice_id = serialized_device_id(device_id)
-    if company_name not in _device_ids:
-        _device_ids[company_name] = dict()
 
-    if car_name not in _device_ids[company_name]:
-        _device_ids[company_name][car_name] = dict()
-
-    if device_id.module_id not in _device_ids[company_name][car_name]:
-        _device_ids[company_name][car_name][device_id.module_id] = dict()
-
-    if sdevice_id not in _device_ids[company_name][car_name][device_id.module_id]:
-        _device_ids[company_name][car_name][device_id.module_id][sdevice_id] = device_id
-        return True
-
-    return False
+    if car_name not in _connected_cars[company_name]:
+        _connected_cars[company_name][car_name] = ConnectedCar(company_name=company_name, car_name=car_name, timestamp=0)
+    return _connected_cars[company_name][car_name].add_device(device_id)
 
 
 def serialized_device_id(device_id: DeviceId) -> str:

--- a/server/database/device_ids.py
+++ b/server/database/device_ids.py
@@ -114,14 +114,19 @@ def clean_up_disconnected_cars_and_modules() -> None:
         _connected_cars.pop(company)
 
 
-def store_connected_device_if_new(company_name: str, car_name: str, device_id: DeviceId) -> bool:
+def store_connected_device_if_new(company_name: str, car_name: str, device_id: DeviceId, timestamp: int) -> bool:
     """Add a device id to the device_ids dictionary if it is not already there.
 
     Returns True if the device id was stored, False otherwise.
     """
 
     if car_name not in _connected_cars[company_name]:
-        _connected_cars[company_name][car_name] = ConnectedCar(company_name=company_name, car_name=car_name, timestamp=0)
+        _connected_cars[company_name][car_name] = ConnectedCar(
+            company_name=company_name,
+            car_name=car_name,
+            timestamp=timestamp,
+            modules={},
+        )
     return _connected_cars[company_name][car_name].add_device(device_id)
 
 

--- a/server/database/tests/test_device_ids.py
+++ b/server/database/tests/test_device_ids.py
@@ -3,14 +3,16 @@ import sys
 sys.path.append("server")
 import unittest
 
-from fleetv2_http_api.models.device_id import DeviceId
-from database.device_ids import (
-    device_ids,
+from fleetv2_http_api.models.device_id import DeviceId   # type: ignore
+from database.device_ids import (  # type: ignore
+    connected_cars,
     clean_up_disconnected_cars_and_modules,
-    clear_device_ids,
-    store_device_id_if_new,
-    remove_device_id,
+    clear_connected_cars,
+    store_connected_device_if_new,
+    remove_connected_device,
     serialized_device_id,
+    ConnectedCar,
+    ConnectedModule
 )
 
 
@@ -23,55 +25,65 @@ class TestDeviceIds(unittest.TestCase):
         self.maxDiff = None
 
     def test_cleaning_up_cars_without_any_device_ids(self):
-        clear_device_ids()
-        store_device_id_if_new("company1", "car1", self.device_1_id)
-        store_device_id_if_new("company1", "car2", self.device_x_id)
-        self.assertEqual(list(device_ids()["company1"].keys()), ["car1", "car2"])
-        remove_device_id("company1", "car1", self.device_1_id)
+        clear_connected_cars()
+        store_connected_device_if_new("company1", "car1", self.device_1_id)
+        store_connected_device_if_new("company1", "car2", self.device_x_id)
+        self.assertEqual(list(connected_cars()["company1"].keys()), ["car1", "car2"])
+        remove_connected_device("company1", "car1", self.device_1_id)
         clean_up_disconnected_cars_and_modules()
         self.assertDictEqual(
-            device_ids(), {"company1": {"car2": {48: {"48_7_role_x": self.device_x_id}}}}
+            connected_cars(), {
+                "company1": {
+                    "car2": ConnectedCar("company1", "car2", 0, {48: ConnectedModule(48, [self.device_x_id])})
+                }
+            }
+            # connected_cars(), {"company1": {"car2": {48: {"48_7_role_x": self.device_x_id}}}}
         )
 
     def test_cleaning_up_modules_without_any_device_ids(self):
-        clear_device_ids()
-        store_device_id_if_new("company1", "car1", self.device_1_id)
-        store_device_id_if_new("company1", "car1", self.device_x_id)
-        remove_device_id("company1", "car1", self.device_x_id)
+        clear_connected_cars()
+        store_connected_device_if_new("company1", "car1", self.device_1_id)
+        store_connected_device_if_new("company1", "car1", self.device_x_id)
+        remove_connected_device("company1", "car1", self.device_x_id)
 
         clean_up_disconnected_cars_and_modules()
         self.assertDictEqual(
-            device_ids(),
+            connected_cars(),
             {
                 "company1": {
-                    "car1": {
-                        45: {"45_2_role1": self.device_1_id},
-                    }
+                    "car1": ConnectedCar(
+                        "company1",
+                        "car1",
+                        0,
+                        {
+                            45: ConnectedModule(45, [self.device_1_id])
+                        }
+                    )
                 }
             },
         )
 
     def test_cleaning_up_companies_without_any_cars(self):
-        clear_device_ids()
-        store_device_id_if_new("company1", "car1", self.device_1_id)
-        store_device_id_if_new("company2", "car1", self.device_x_id)
-        store_device_id_if_new("company3", "carA", self.device_123_id)
-        store_device_id_if_new("company3", "carB", self.device_456_id)
+        clear_connected_cars()
+        store_connected_device_if_new("company1", "car1", self.device_1_id)
+        store_connected_device_if_new("company2", "car1", self.device_x_id)
+        store_connected_device_if_new("company3", "carA", self.device_123_id)
+        store_connected_device_if_new("company3", "carB", self.device_456_id)
 
-        store_device_id_if_new("company1", "car1", self.device_1_id)
+        store_connected_device_if_new("company1", "car1", self.device_1_id)
 
-        remove_device_id("company2", "car1", self.device_x_id)
+        remove_connected_device("company2", "car1", self.device_x_id)
         clean_up_disconnected_cars_and_modules()
-        self.assertListEqual(list(device_ids().keys()), ["company1", "company3"])
+        self.assertListEqual(list(connected_cars().keys()), ["company1", "company3"])
 
-        remove_device_id("company1", "car1", serialized_device_id(self.device_1_id))
+        remove_connected_device("company1", "car1", self.device_1_id)
         clean_up_disconnected_cars_and_modules()
-        self.assertListEqual(list(device_ids().keys()), ["company3"])
+        self.assertListEqual(list(connected_cars().keys()), ["company3"])
 
     def test_cleaning_up_empty_device_ids_dict_has_no_effect(self):
-        clear_device_ids()
+        clear_connected_cars()
         clean_up_disconnected_cars_and_modules()
-        self.assertDictEqual(device_ids(), {})
+        self.assertDictEqual(connected_cars(), {})
 
 
 if __name__ == "__main__":

--- a/server/fleetv2_http_api/controllers/car_controller.py
+++ b/server/fleetv2_http_api/controllers/car_controller.py
@@ -7,13 +7,15 @@ from fleetv2_http_api.models.car import Car  # noqa: E501
 from fleetv2_http_api import util
 
 
-def available_cars(wait=None):  # noqa: E501
+def available_cars(wait=None, since=None):  # noqa: E501
     """available_cars
 
     Return list of available cars for all companies registered in the database. # noqa: E501
 
     :param wait: An empty parameter. If specified, the method waits for predefined period of time, until some data to be sent in response are available.
     :type wait: bool
+    :param since: A Unix timestamp; if specified, the method returns all messages inclusivelly newer than the specified timestamp \\ (i.e., messages with timestamp greater than or equal to the &#39;since&#39; timestamp)
+    :type since: int
 
     :rtype: Union[List[Car], Tuple[List[Car], int], Tuple[List[Car], int, Dict[str, str]]
     """

--- a/server/fleetv2_http_api/impl/controllers.py
+++ b/server/fleetv2_http_api/impl/controllers.py
@@ -148,7 +148,7 @@ def token_refresh(
     return _log_and_respond(token, 200, "Jwt token refreshed.")
 
 
-def available_cars(wait: bool = False) -> tuple[list[Car], int]:
+def available_cars(wait: bool = False, since: int = 0) -> tuple[list[Car], int]:
     """available_cars
 
     Return list of available cars for all companies registered in the database. # noqa: E501

--- a/server/fleetv2_http_api/impl/controllers.py
+++ b/server/fleetv2_http_api/impl/controllers.py
@@ -21,7 +21,7 @@ from database.database_controller import (  # type: ignore
     cleanup_device_commands_and_warn_before_future_commands,
 )
 from database.database_controller import list_messages as _list_messages  # type: ignore
-from database.device_ids import store_device_id_if_new, device_ids, serialized_device_id  # type: ignore
+from database.device_ids import store_connected_device_if_new, connected_cars, serialized_device_id  # type: ignore
 from database.time import timestamp  # type: ignore
 from fleetv2_http_api.impl.message_wait import MessageWaitObjManager  # type: ignore
 from fleetv2_http_api.impl.car_wait import CarWaitObjManager  # type: ignore
@@ -156,7 +156,7 @@ def available_cars(wait: bool = False, since: int = 0) -> tuple[list[Car], int]:
     :rtype: Union[list[Car], tuple[list[Car], int], tuple[list[Car], int, dict[str, str]]
     """
     cars: list[Car] = list()
-    device_dict = device_ids()
+    device_dict = connected_cars()
     for company_name in device_dict:
         for car_name in device_dict[company_name]:
             cars.append(Car(company_name, car_name))
@@ -193,7 +193,7 @@ def available_devices(
     company_and_car_name = f"Company='{company_name}', car='{car_name}'"
     empty_response_body: Collection = [] if module_id is None else {}
 
-    device_dict = device_ids()
+    device_dict = connected_cars()
     if company_name not in device_dict:
         return _log_and_respond(
             empty_response_body, 404, f"No company named '{company_name}' is registered."
@@ -205,11 +205,11 @@ def available_devices(
         )
 
     if module_id is None:
-        car_modules = device_dict[company_name][car_name]
+        car_modules = device_dict[company_name][car_name].modules
         modules = [_available_module(company_name, car_name, id) for id in car_modules]
         return _log_and_respond(modules, 200, f"listing available modules ({company_and_car_name})")
     else:
-        if module_id not in device_dict[company_name][car_name]:
+        if module_id not in device_dict[company_name][car_name].modules:
             return _log_and_respond(
                 empty_response_body,
                 404,
@@ -270,7 +270,7 @@ def list_commands(
                 awaited_commands, 200, f"Returning awaited commands ({company_and_car_name})."
             )
         else:
-            if company_name not in device_ids() or car_name not in device_ids()[company_name]:
+            if company_name not in connected_cars() or car_name not in connected_cars()[company_name]:
                 return _log_and_respond(
                     [], 404, f"No commands available before timeout ({company_and_car_name})."
                 )
@@ -425,13 +425,13 @@ def _message_list_from_request_body(body: list[dict | Message]) -> list[Message]
 
 
 def _available_module(company_name: str, car_name: str, module_id: int) -> Module:
-    device_id_list = list((device_ids()[company_name][car_name][module_id]).values())
+    device_id_list = connected_cars()[company_name][car_name].modules[module_id].device_ids
     return Module(module_id, device_id_list)
 
 def _check_and_handle_first_status(company: str, car: str, messages: list[Message]) -> str:
     command_removal_warnings = ""
     for msg in messages:
-        first_status_was_sent = store_device_id_if_new(company, car, msg.device_id)
+        first_status_was_sent = store_connected_device_if_new(company, car, msg.device_id)
         sdevice_id = serialized_device_id(msg.device_id)
         if first_status_was_sent:
             command_removal_warnings = "\n".join(
@@ -450,8 +450,7 @@ def _check_sent_commands(
         return errors, code
     for cmd in messages:
         module_id = cmd.device_id.module_id
-        sdevice_id = serialized_device_id(cmd.device_id)
-        msg, code = _check_device_availability(company_name, car_name, module_id, sdevice_id)
+        msg, code = _check_device_availability(company_name, car_name, module_id, cmd.device_id)
         if code != 200:
             return msg, code
     return "", 200
@@ -479,22 +478,22 @@ def _check_message_types(expected_message_type: str, *messages: Message) -> str:
 
 
 def _check_device_availability(
-    company_name: str, car_name: str, module_id: int, sdevice_id: str
+    company: str, car: str, module_id: int, device_id: DeviceId
 ) -> tuple[str, int]:
-    device_dict = device_ids()
-    msg, code = _check_car_availability(company_name, car_name)
+    device_dict = connected_cars()
+    msg, code = _check_car_availability(company, car)
     if code != 200:
         return msg, code
-    elif module_id not in device_dict[company_name][car_name]:
+    elif module_id not in device_dict[company][car].modules:
         return (
             f"No module with id '{module_id}' is available in car "
-            f"'{car_name}' under the company '{company_name}'",
+            f"'{car}' under the company '{company}'",
             404,
         )
-    elif sdevice_id not in device_dict[company_name][car_name][module_id]:
+    elif not device_dict[company][car].is_connected(device_id):
         return (
-            f"No device with id '{sdevice_id}' is available in module "
-            f"'{module_id}' in car '{car_name}' under the company '{company_name}'",
+            f"No device with id '{serialized_device_id(device_id)}' is available in module "
+            f"'{module_id}' in car '{car}' under the company '{company}'",
             404,
         )
     else:
@@ -502,7 +501,7 @@ def _check_device_availability(
 
 
 def _check_car_availability(company_name: str, car_name: str) -> tuple[str, int]:
-    device_dict = device_ids()
+    device_dict = connected_cars()
     if company_name not in device_dict:
         return f"No car is available under a company '{company_name}'.", 404  # type: ignore
     elif car_name not in device_dict[company_name]:

--- a/server/fleetv2_http_api/impl/tests/test_wait_for_messages.py
+++ b/server/fleetv2_http_api/impl/tests/test_wait_for_messages.py
@@ -6,7 +6,7 @@ import os
 import time
 import unittest
 
-from database.device_ids import clear_device_ids, serialized_device_id  # type: ignore
+from database.device_ids import clear_connected_cars, serialized_device_id  # type: ignore
 from database.database_controller import set_test_db_connection  # type: ignore
 from database.time import timestamp  # type: ignore
 from fleetv2_http_api.impl.controllers import (  # type: ignore
@@ -30,7 +30,7 @@ class Test_Ask_For_Statuses_Not_Available_At_The_Time_Of_The_Request(unittest.Te
         if os.path.exists("./example.db"):
             os.remove("./example.db")
         set_test_db_connection("/example.db")
-        clear_device_ids()
+        clear_connected_cars()
         payload_example = Payload(
             message_type="STATUS", encoding="JSON", data={"message": "Device is running"}
         )
@@ -189,7 +189,7 @@ class Test_Ask_For_Commands_Not_Available_At_The_Time_Of_The_Request(unittest.Te
         if os.path.exists("./example.db"):
             os.remove("./example.db")
         set_test_db_connection("/example.db")
-        clear_device_ids()
+        clear_connected_cars()
         self.device_id = DeviceId(module_id=42, type=7, role="test_device_1", name="Left light")
         self.status = Message(123456789, self.device_id, Payload("STATUS", "JSON", {}))
         self.command = Message(123456789, self.device_id, Payload("COMMAND", "JSON", {}))
@@ -440,7 +440,7 @@ class Test_Waiting_For_Messsages_From_Multiple_Cars(unittest.TestCase):
         if os.path.exists("./example.db"):
             os.remove("./example.db")
         set_test_db_connection("/example.db")
-        clear_device_ids()
+        clear_connected_cars()
         payload_example = Payload(
             message_type="STATUS", encoding="JSON", data={"message": "Device is running"}
         )

--- a/server/fleetv2_http_api/impl/tests/test_waiting_for_cars.py
+++ b/server/fleetv2_http_api/impl/tests/test_waiting_for_cars.py
@@ -8,7 +8,7 @@ sys.path.append("server")
 
 from fleetv2_http_api.models import Payload, Message, Car, DeviceId  # type: ignore
 from enums import MessageType, EncodingType  # type: ignore
-from database.database_controller import set_test_db_connection, clear_device_ids  # type: ignore
+from database.database_controller import set_test_db_connection, clear_connected_cars  # type: ignore
 from fleetv2_http_api.impl.controllers import (  # type: ignore
     available_cars, send_statuses, set_car_wait_timeout_s
 )
@@ -20,7 +20,7 @@ class Test_Waiting_For_Available_Cars(unittest.TestCase):
         if os.path.exists("./example.db"):
             os.remove("./example.db")
         set_test_db_connection("/example.db")
-        clear_device_ids()
+        clear_connected_cars()
         self.status_1 = Message(
             device_id=DeviceId(module_id=47, type=5, role="test_device", name="Test Device"),
             payload=Payload(
@@ -73,7 +73,7 @@ class Test_Filtering_By_Since_Parameter(unittest.TestCase):
         if os.path.exists("./example.db"):
             os.remove("./example.db")
         set_test_db_connection("/example.db")
-        clear_device_ids()
+        clear_connected_cars()
         self.status = Message(
             device_id=DeviceId(module_id=47, type=5, role="test_device", name="Test Device"),
             payload=Payload(

--- a/server/fleetv2_http_api/impl/tests/test_waiting_for_cars.py
+++ b/server/fleetv2_http_api/impl/tests/test_waiting_for_cars.py
@@ -98,8 +98,18 @@ class Test_Filtering_By_Since_Parameter(unittest.TestCase):
         send_statuses("test_company", "car_3", [self.status])
         mocked_time_in_ms.return_value = 4000
         send_statuses("test_company", "car_4", [self.status])
-        cars, code = available_cars(wait=True, since=2500)
+        cars, code = available_cars(since=2500)
         self.assertEqual(len(cars), 2)
+        self.assertEqual(cars[0].car_name, "car_3")
+        self.assertEqual(cars[1].car_name, "car_4")
+
+    @patch("database.time._time_in_ms")
+    def test_request_timeout_for_when_only_old_car_is_connected(self, mocked_time_in_ms: Mock):
+        set_car_wait_timeout_s(0.2)
+        mocked_time_in_ms.return_value = 1000
+        send_statuses("test_company", "car_1", [self.status])
+        cars, code = available_cars(wait=True, since=4500)
+        self.assertEqual(len(cars), 0)
 
     def tearDown(self) -> None:
         if os.path.exists("./example.db"):

--- a/server/fleetv2_http_api/openapi/openapi.yaml
+++ b/server/fleetv2_http_api/openapi/openapi.yaml
@@ -90,6 +90,19 @@ paths:
           nullable: true
           type: boolean
         style: form
+      - description: "A Unix timestamp; if specified, the method returns all messages\
+          \ inclusivelly newer than the specified timestamp \\ (i.e., messages with\
+          \ timestamp greater than or equal to the 'since' timestamp)"
+        example: 1699262836
+        explode: true
+        in: query
+        name: since
+        required: false
+        schema:
+          default: 0
+          nullable: true
+          type: integer
+        style: form
       responses:
         "200":
           content:

--- a/server/fleetv2_http_api/openapi/openapi.yaml
+++ b/server/fleetv2_http_api/openapi/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: GPLv3
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: Fleet v2 HTTP API
-  version: 2.2.3
+  version: 2.3.0
 servers:
 - url: /v2/protocol
 security:


### PR DESCRIPTION
The GET method of /cars endpoint of the API now allows returning only cars that connected to the server AT or AFTER a specific time corresponding to a UNIX timestamp in milliseconds specified by the query parameter 'since'.

Closes BAIP-237