### PR TITLE
Baf 895/broken wait mechanism for commands to nonexistent car

### DIFF
--- a/integration_tests/__main__.py
+++ b/integration_tests/__main__.py
@@ -56,7 +56,7 @@ def _run_tests(show_test_names: bool = True) -> None:
             pattern, dir = "test_*.py", path
         suite.addTests(unittest.TestLoader().discover(dir, pattern=pattern))
     verbosity = 2 if show_test_names else 1
-    unittest.TextTestRunner(verbosity=verbosity, buffer=True).run(suite)
+    unittest.TextTestRunner(verbosity=verbosity).run(suite)
 
 
 if __name__ == "__main__":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.2
 
 info:
   title: Fleet v2 HTTP API
-  version: 2.4.1
+  version: 2.4.2
   description: HTTP-based API for Fleet Protocol v2 serving for communication between the External Server and the end users.
   contact:
     email: jiri.strouhal@bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "server"
-version = "2.4.1"
+version = "2.4.2"
 
 
 [tool.setuptools.packages.find]

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append("server")
 import logging
-import requests
+import requests  # type: ignore
 
 from apscheduler.schedulers.background import BackgroundScheduler  # type: ignore
 
@@ -18,6 +18,10 @@ from fleetv2_http_api.impl.controllers import (  # type: ignore
 )
 from fleetv2_http_api.controllers.security_controller import set_auth_params  # type: ignore
 import database.script_args as script_args  # type: ignore
+
+
+logging.getLogger("werkzeug").setLevel(logging.DEBUG)
+
 
 def _clean_up_messages() -> None:
     """Clean up messages from the database."""

--- a/server/fleetv2_http_api/impl/message_wait.py
+++ b/server/fleetv2_http_api/impl/message_wait.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
-from typing import Any
 import time
 import threading
+
+from fleetv2_http_api.models.message import Message  # type: ignore
+from database.time import timestamp as _timestamp  # type: ignore
 
 
 class MessageWaitObjManager:
@@ -16,28 +18,28 @@ class MessageWaitObjManager:
     @property
     def timeout_ms(self) -> int: return self._timeout_ms
 
-    def add_response_content_and_stop_waiting(self, company: str, car: str, reponse_content: list[Any]) -> None:
+    def add_response_content_and_stop_waiting(self, company: str, car: str, reponse_content: list[Message]) -> None:
         """Make the next wait object in the queue to respond with specified 'reponse_content' and remove it from the queue."""
         wait_objs = self._get_wait_objects_for_given_car(company, car)
         if wait_objs:
             self._send_content_to_all_wait_objs(wait_objs, reponse_content)
             self._remove_wait_obj_list(company, car)
 
-    def new_wait_obj(self, company_name: str, car_name: str) -> MessageWaitObj:
+    def new_wait_obj(self, company: str, car_name: str) -> MessageWaitObj:
         """Create a new wait object and adds it to the wait queue for given company and car."""
-        wait_obj = MessageWaitObj(company_name, car_name, self._timeout_ms)
+        wait_obj = MessageWaitObj(company, car_name, self._timeout_ms)
 
-        if not company_name in self._wait_dict:
-            self._wait_dict[company_name] = dict()
-        if not car_name in self._wait_dict[company_name]:
-            self._wait_dict[company_name][car_name] = list()
+        if not company in self._wait_dict:
+            self._wait_dict[company] = dict()
+        if not car_name in self._wait_dict[company]:
+            self._wait_dict[company][car_name] = list()
 
-        self._wait_dict[company_name][car_name].append(wait_obj)
+        self._wait_dict[company][car_name].append(wait_obj)
         return wait_obj
 
-    def remove_wait_obj(self, wait_obj:MessageWaitObj) -> None:
+    def remove_wait_obj(self, wait_obj: MessageWaitObj) -> None:
         """Remove the wait object from the wait queue."""
-        company, car = wait_obj.company_name, wait_obj.car_name
+        company, car = wait_obj.company, wait_obj.car_name
         if company in self._wait_dict:
             if car in self._wait_dict[company]:
                 if wait_obj in self._wait_dict[company][car]:
@@ -52,15 +54,19 @@ class MessageWaitObjManager:
         self._check_nonnegative_timeout(timeout_ms)
         self._timeout_ms = timeout_ms
 
-    def wait_and_get_reponse(self, company_name: str, car_name: str) -> list[Any]:
+    def wait_and_get_reponse(self, company: str, car_name: str) -> list[Message]:
         """Wait for the next wait object in queue to respond and returns the response content.
         The queue is identified by given company and car."""
-        wait_obj = self.new_wait_obj(company_name, car_name)
-        reponse = wait_obj.wait_and_get_response()
+        wait_obj = self.new_wait_obj(company, car_name)
+        msgs = wait_obj.wait_and_get_response()
         self.remove_wait_obj(wait_obj)
-        return reponse
+        for msg in msgs:
+            if msg.timestamp is None:
+                msg.timestamp = _timestamp()
 
-    def _send_content_to_all_wait_objs(self, wait_objs: list[MessageWaitObj], reponse_content: list[Any]) -> None:
+        return msgs
+
+    def _send_content_to_all_wait_objs(self, wait_objs: list[MessageWaitObj], reponse_content: list[Message]) -> None:
         for wait_obj in wait_objs:
             wait_obj.add_reponse_content_and_stop_waiting(reponse_content)
 
@@ -83,23 +89,23 @@ class MessageWaitObjManager:
 
 class MessageWaitObj:
     def __init__(self, company: str, car: str, timeout_ms: int) -> None:
-        self._company_name = company
+        self._company = company
         self._car_name = car
-        self._response_content: list[Any] = list()
+        self._response_content: list[Message] = list()
         self._timeout_ms = timeout_ms
         self._condition = threading.Condition()
 
     @property
-    def company_name(self) -> str: return self._company_name
+    def company(self) -> str: return self._company
     @property
     def car_name(self) -> str: return self._car_name
 
-    def add_reponse_content_and_stop_waiting(self, content: list[Any]) -> None:
+    def add_reponse_content_and_stop_waiting(self, content: list[Message]) -> None:
         self._response_content = content.copy()
         with self._condition:
             self._condition.notify()
 
-    def wait_and_get_response(self) -> list[Any]:
+    def wait_and_get_response(self) -> list[Message]:
         """Wait for the response object to be set and then return it."""
         with self._condition:
             self._condition.wait(timeout=self._timeout_ms/1000)

--- a/server/fleetv2_http_api/openapi/openapi.yaml
+++ b/server/fleetv2_http_api/openapi/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: GPLv3
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: Fleet v2 HTTP API
-  version: 2.4.1
+  version: 2.4.2
 servers:
 - url: /v2/protocol
 security:


### PR DESCRIPTION
The problem description on YouTrack: https://youtrack.bringauto.com/issue/BAF-895/Fleet-protocol-api-wait-mechanism-not-working

Cause: The database may contain commands for unavailable cars (this is correct behavior - when returning commands after the car reconnects, these old commands are ignored). The method "list_commands" in impl/controllers.py was however written assuming (incorrectly) that no commands ever exist for unavailable cars. Thus, the method was returning these "orphan" commands, which caused immediate response and de facto turned off the wait mechanism even when this was required to apply and was expected to hold the server's response until the car connected. 

Closes BAF-895.
