### PR TITLE
Return 404 when waiting for statuses times out

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.2
 
 info:
   title: Fleet v2 HTTP API
-  version: 2.5.0
+  version: 2.6.0
   description: HTTP-based API for Fleet Protocol v2 serving for communication between the External Server and the end users.
   contact:
     email: jiri.strouhal@bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "server"
-version = "2.5.0"
+version = "2.6.0"
 
 
 [tool.setuptools.packages.find]

--- a/server/fleetv2_http_api/impl/controllers.py
+++ b/server/fleetv2_http_api/impl/controllers.py
@@ -303,12 +303,9 @@ def list_statuses(
             else:
                 return _log_and_respond( awaited, 200, f"Returning awaited statuses ({car}).")
         else:
-            if _car_availability(company_name, car_name)[1] == 200:
-                return _log_and_respond([], 200, f"No statuses are available before timeout ({car}).")
-            else:
-                return _log_and_respond(
-                    [], 404, f"No devices (nor statuses) available before timeout ({car}).",
-                )
+            return _log_and_respond(
+                [], 404, f"No statuses available before timeout ({car}).",
+            )
 
 
 def send_commands(

--- a/server/fleetv2_http_api/impl/controllers.py
+++ b/server/fleetv2_http_api/impl/controllers.py
@@ -290,7 +290,9 @@ def list_statuses(
         if _car_availability(company_name, car_name)[1] == 200:
             return _log_and_respond([], 200, f"No statuses are available ({car}).")
         else:
-            return _log_and_respond([], 404, f"Car is not available. No statuses can be returned.")
+            return _log_and_respond(
+                [], 404, f"Car ({car}) not available. No statuses can be returned."
+            )
     else:
         awaited: list[Message] = _status_wait_manager.wait_and_get_reponse(
             company_name, car_name
@@ -298,14 +300,12 @@ def list_statuses(
         if awaited:
             if since is not None and awaited[-1].timestamp < since:
                 return _log_and_respond(
-                    [], 200, f"Found statuses, but all older than 'since' ({car}).",
+                    [], 200, f"Found only statuses older than 'since' ({car}).",
                 )
             else:
-                return _log_and_respond( awaited, 200, f"Returning awaited statuses ({car}).")
+                return _log_and_respond(awaited, 200, f"Returning awaited statuses ({car}).")
         else:
-            return _log_and_respond(
-                [], 404, f"No statuses available before timeout ({car}).",
-            )
+            return _log_and_respond([], 404, f"No statuses available before timeout ({car}).")
 
 
 def send_commands(

--- a/tests/api/test_wait_for_messages.py
+++ b/tests/api/test_wait_for_messages.py
@@ -451,7 +451,7 @@ class Test_Car_Availability(unittest.TestCase):
         result = list_statuses("test_company", "test_car", wait=True)
         self.assertEqual(result[1], 404)
 
-    def test_waiting_for_statuses_of_car_available_before_timeout_but_wihout_new_statuses_yields_200(self):
+    def test_waiting_for_statuses_of_car_available_before_timeout_but_wihout_new_statuses_yields_404(self):
         status = Message(device_id=self.device_id, payload=self.payload_example)
         send_statuses("test_company", "test_car", [status])
         self.assertIn(Car("test_company", "test_car"), available_cars("test_company")[0])
@@ -459,7 +459,7 @@ class Test_Car_Availability(unittest.TestCase):
         current_timestamp = timestamp()
         result = list_statuses("test_company", "test_car", wait=True, since=current_timestamp)
         self.assertEqual(result[0], [])
-        self.assertEqual(result[1], 200)
+        self.assertEqual(result[1], 404)
 
     def test_waiting_for_commands_of_car_not_becoming_available_before_timeout_yields_404(self):
         current_timestamp = timestamp()

--- a/tests_integration/__main__.py
+++ b/tests_integration/__main__.py
@@ -56,7 +56,7 @@ def _run_tests(show_test_names: bool = True) -> None:
             pattern, dir = "test_*.py", path
         suite.addTests(unittest.TestLoader().discover(dir, pattern=pattern))
     verbosity = 2 if show_test_names else 1
-    unittest.TextTestRunner(verbosity=verbosity).run(suite)
+    unittest.TextTestRunner(verbosity=verbosity, buffer=True).run(suite)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Returning code 200 when a request for statuses (with wait=True) times out does not comply with the expectation that the data will at some point become available and will be returned. Thus, the return code 200 is replaced with 404. 

Other changes include shortening of log messages, adding a car name to a log message in list_statuses method and not printing logs to console when running integration tests.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated API and project version from 2.5.0 to 2.6.0, indicating new enhancements and improvements.
- **Bug Fixes**
	- Improved clarity of API response messages for status checks on cars.
	- Adjusted HTTP status code handling in response to status checks to reflect accurate outcomes.
- **Tests**
	- Updated test cases to align with new response behaviors and expected status codes.
- **Chores**
	- Enhanced test output handling by enabling output buffering during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->