### PR TITLE
Use base docker bringauto/python-environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
-FROM python:3.10-alpine
+FROM bringauto/python-environment:latest
 
 WORKDIR /home/bringauto
 
 COPY ./requirements.txt /home/bringauto
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN "$PYTHON_ENVIRONMENT_PYTHON3" -m pip install --no-cache-dir -r requirements.txt
 
-RUN mkdir /home/bringauto/log
 COPY config /home/bringauto/config
 COPY server /home/bringauto/server
 
 EXPOSE 8080
 
-ENTRYPOINT ["python3"]
-CMD ["-m", "server", "config/config.json"]
+USER 5000:5000
+RUN mkdir /home/bringauto/log
+
+ENTRYPOINT ["bash", "-c", "$PYTHON_ENVIRONMENT_PYTHON3 -m server $0 $@"]
+CMD ["config/config.json"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ COPY server /home/bringauto/server
 
 EXPOSE 8080
 
-USER 5000:5000
 RUN mkdir /home/bringauto/log
 
 ENTRYPOINT ["bash", "-c", "$PYTHON_ENVIRONMENT_PYTHON3 -m server $0 $@"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,8 +11,8 @@ services:
       - 8080:8080
     networks:
       - api-network
-    entrypoint:
-      ["python3", "-m", "server", "config/config.json", "--location", "postgresql-database"]
+    command:
+      ["config/config.json", "--location", "postgresql-database"]
 
   postgresql-database:
     image: postgres:16

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.2
 
 info:
   title: Fleet v2 HTTP API
-  version: 2.7.0
+  version: 2.7.1
   description: HTTP-based API for Fleet Protocol v2 serving for communication between the External Server and the end users.
   contact:
     email: jiri.strouhal@bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "server"
-version = "2.7.0"
+version = "2.7.1"
 
 
 [tool.setuptools.packages.find]

--- a/server/fleetv2_http_api/openapi/openapi.yaml
+++ b/server/fleetv2_http_api/openapi/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: GPLv3
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: Fleet v2 HTTP API
-  version: 2.7.0
+  version: 2.7.1
 servers:
 - url: /v2/protocol
 security:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated OpenAPI specification to version 2.7.1, enhancing endpoint descriptions for better clarity.
  
- **Bug Fixes**
	- Adjusted server initialization commands in Docker configuration for improved functionality.

- **Documentation**
	- Enhanced API documentation with detailed descriptions and examples for various endpoints.

- **Chores**
	- Updated project version from 2.7.0 to 2.7.1 in relevant configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->