### PR TITLE
Baf 991/more logging options in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The configuration file is located in `config` directory. The file contains the f
 
 **Check carefully the correct name of the database the server should connect to.**
 
-- `logging` - contains the following keys:
-  - `log-path` - path to the directory where logs will be stored.
-  - `verbosity` - if `True`, the server will print logs to both file and to console and set the logging level to `DEBUG`. If `False`, the server will only print logs to the file and set the logging level to `INFO`.
+- `logging` - contains the keys `console`and `file` for printing the logs into a console and a file, respectively. The `file` contains field `path` to set the (absolute or relative) path to the directory to store the logs. Both contain the following keys:
+  - `level` - logging level as a string (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Case-insensitive.
+  - `use` - set to `True` to allow to print the logs, otherwise set to `False`.
 - `database` - settings for the database associated with the server.
   - `server` - settings for the database server.
     - `username`

--- a/config/config.json
+++ b/config/config.json
@@ -1,11 +1,11 @@
 {
     "logging": {
         "console": {
-            "level": "debug",
+            "level": "info",
             "use": true
         },
         "file": {
-            "level": "debug",
+            "level": "info",
             "use": true,
             "path": "./log/"
         }

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,14 @@
 {
     "logging": {
-        "log_path": "./log/",
-        "verbose": true
+        "console": {
+            "level": "debug",
+            "use": true
+        },
+        "file": {
+            "level": "debug",
+            "use": true,
+            "path": "./log/"
+        }
     },
     "http_server": {
         "base_uri": "https://test-api.bringautofleet.com/v2/protocol",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.2
 
 info:
   title: Fleet v2 HTTP API
-  version: 2.7.0
+  version: 2.8.0
   description: HTTP-based API for Fleet Protocol v2 serving for communication between the External Server and the end users.
   contact:
     email: jiri.strouhal@bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "server"
-version = "2.7.0"
+version = "2.8.0"
 
 
 [tool.setuptools.packages.find]

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -1,4 +1,5 @@
 import sys
+
 sys.path.append("server")
 import logging
 import requests  # type: ignore
@@ -17,7 +18,7 @@ from server.fleetv2_http_api.impl.controllers import (  # type: ignore
     set_car_wait_timeout_s,
     set_status_wait_timeout_s,
     set_command_wait_timeout_s,
-    init_security
+    init_security,
 )
 from server.fleetv2_http_api.controllers.security_controller import set_auth_params  # type: ignore
 import server.database.script_args as script_args  # type: ignore
@@ -35,15 +36,15 @@ def _clean_up_messages() -> None:
     remove_old_messages(current_timestamp=timestamp())
 
 
-def _connect_to_database(vals:script_args.ScriptArgs) -> None:
+def _connect_to_database(vals: script_args.ScriptArgs) -> None:
     """Clear previously stored available devices and connect to the database."""
     clear_connected_cars()
     set_db_connection(
-        dblocation = vals.argvals["location"],
-        port = vals.argvals["port"],
-        username = vals.argvals["username"],
-        password = vals.argvals["password"],
-        db_name = vals.argvals["database_name"]
+        dblocation=vals.argvals["location"],
+        port=vals.argvals["port"],
+        username=vals.argvals["username"],
+        password=vals.argvals["password"],
+        db_name=vals.argvals["database_name"],
     )
 
 
@@ -71,22 +72,24 @@ def _retrieve_keycloak_public_key(keycloak_url: str, realm: str) -> str:
         return ""
 
 
-SPECIFICATION_DIR = os.path.join('.', 'server', 'fleetv2_http_api', 'openapi')
-APP_NAME = 'Fleet v2 HTTP API'
+SPECIFICATION_DIR = os.path.join(".", "server", "fleetv2_http_api", "openapi")
+APP_NAME = "Fleet v2 HTTP API"
 
 
 def run_server(port: int = 8080) -> None:
     """Run the Fleet Protocol v2 HTTP API server."""
     app = connexion.App(APP_NAME.lower().replace(" ", "-"), specification_dir=SPECIFICATION_DIR)
     app.app.json_encoder = encoder.JSONEncoder
-    app.add_api('openapi.yaml',
-                arguments={'title': 'Fleet Protocol v2 HTTP API'},
-                pythonic_params=True)
+    app.add_api(
+        "openapi.yaml", arguments={"title": "Fleet Protocol v2 HTTP API"}, pythonic_params=True
+    )
     app.run(port=port)
 
 
-if __name__ == '__main__':
-    vals = script_args.request_and_get_script_arguments("Run the Fleet Protocol v2 HTTP API server.")
+if __name__ == "__main__":
+    vals = script_args.request_and_get_script_arguments(
+        "Run the Fleet Protocol v2 HTTP API server."
+    )
     config = vals.config
     configure_logging(COMPONENT_NAME, config)
     _connect_to_database(vals)
@@ -100,13 +103,12 @@ if __name__ == '__main__':
         secret_key=config.security.client_secret_key,
         scope=config.security.scope,
         realm=config.security.realm,
-        callback=str(config.http_server.base_uri)
+        callback=str(config.http_server.base_uri),
     )
     set_auth_params(
         public_key=_retrieve_keycloak_public_key(
-            keycloak_url=str(config.security.keycloak_url),
-            realm=config.security.realm
+            keycloak_url=str(config.security.keycloak_url), realm=config.security.realm
         ),
-        client_id=config.security.client_id
+        client_id=config.security.client_id,
     )
     run_server(config.http_server.port)

--- a/server/config.py
+++ b/server/config.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
-from typing import Any
+from typing import Any, Literal
 import pydantic
 import json
+
+
+LoggingLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 
 class APIConfig(pydantic.BaseModel):
@@ -13,8 +16,18 @@ class APIConfig(pydantic.BaseModel):
 
 
 class Logging(pydantic.BaseModel):
-    log_path: str
-    verbose: bool
+    console: HandlerConfig
+    file: HandlerConfig
+
+    class HandlerConfig(pydantic.BaseModel):
+        level: LoggingLevel
+        use: bool
+        path: str = ""
+
+        @pydantic.field_validator("level", mode="before")
+        @classmethod
+        def validate_command(cls, level: str) -> str:
+            return level.upper()
 
 
 class HTTPServer(pydantic.BaseModel):

--- a/server/database/security.py
+++ b/server/database/security.py
@@ -44,18 +44,15 @@ def get_admin(key: str) -> AdminDB | None:
     loaded_admins = get_loaded_admins()
     for admin in loaded_admins:
         if admin.key == key:
-            _logger.info("Retrieved API key from cache.")
             return admin
 
     with Session(_get_connection_source()) as session:
         try:
-            _logger.info("Retrieving API key from database.")
             result = session.execute(select(_AdminBase).where(_AdminBase.key == key)).first()
             if result is None:
                 _logger.debug("API key not found.")
                 return None
             else:
-                _logger.debug("Retrieved API key from database.")
                 admin_base: _AdminBase = result[0]
                 admin = AdminDB(id=admin_base.id, name=admin_base.name, key=admin_base.key)
                 store_admin(admin)

--- a/server/fleetv2_http_api/openapi/openapi.yaml
+++ b/server/fleetv2_http_api/openapi/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: GPLv3
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: Fleet v2 HTTP API
-  version: 2.7.0
+  version: 2.8.0
 servers:
 - url: /v2/protocol
 security:

--- a/server/logs.py
+++ b/server/logs.py
@@ -25,6 +25,9 @@ def configure_logging(component_name: str, config: _APIConfig) -> None:
             _configure_logging_to_console(log_config.console, component_name)
         if log_config.file.use:
             _configure_logging_to_file(log_config.file, component_name)
+        logging.getLogger(LOGGER_NAME).setLevel(
+            logging.DEBUG
+        )  # This ensures the logging level will be fully determined by the handlers
     except ValueError as ve:
         logging.error(f"{component_name}: Configuration error: {ve}")
         raise

--- a/server/logs.py
+++ b/server/logs.py
@@ -59,6 +59,8 @@ def configure_logging(component_name: str, config: APIConfig) -> None:
             console_handler.setFormatter(formatter)
             logger.addHandler(console_handler)
 
+        logger.propagate = False
+
     except ValueError as ve:
         logging.error(f"{component_name}: Configuration error: {ve}")
         raise

--- a/server/logs.py
+++ b/server/logs.py
@@ -53,7 +53,7 @@ def _configure_logging_to_file(config: _Logging.HandlerConfig, component_name: s
     The file logging is configured to use the logging level and format specified in the configuration.
     """
     if not config.path:
-        raise ValueError(f"Log directory does not exist: {config.path}. Check the config file.")
+        raise ValueError("Log path is not specified in the configuration. Check the config file.")
     file_path = os.path.join(config.path, _log_file_name(component_name) + ".log")
     handler = logging.handlers.RotatingFileHandler(file_path, maxBytes=10485760, backupCount=5)
     handler.setLevel(config.level)

--- a/tests/config/test_config.json
+++ b/tests/config/test_config.json
@@ -7,7 +7,7 @@
         "file": {
             "level": "debug",
             "use": true,
-            "path": "./log/"
+            "path": "./log"
         }
     },
     "http_server": {

--- a/tests/config/test_config.json
+++ b/tests/config/test_config.json
@@ -1,7 +1,14 @@
 {
     "logging": {
-        "log_path": "./log/",
-        "verbose": true
+        "console": {
+            "level": "debug",
+            "use": true
+        },
+        "file": {
+            "level": "debug",
+            "use": true,
+            "path": "./log/"
+        }
     },
     "http_server": {
         "base_uri": "https://test-api.bringautofleet.com/v2/protocol",


### PR DESCRIPTION
The previous very simple logging configuration has been considered insufficient for controlling log output. 

The previous structure 
{
   "verbose": <\boolean\>,
   "log_path": \<path\>
}

has been replaced with 

{
        "console": {
            "level": \<level-name\>,
            "use":  \<boolean\>
        },
        "file": {
            "level": \<level-name\>,
            "use":  \<boolean\>,
            "path": \<path\>
        }
 }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced logging configuration with separate settings for console and file outputs.
  - Updated OpenAPI documentation, including new endpoints and detailed descriptions for existing ones.

- **Bug Fixes**
  - Improved clarity and usability of configuration instructions in the README.

- **Documentation**
  - Expanded OAuth2 configuration guidance for Keycloak authentication.
  - Updated API specifications to version 2.8.0 with detailed endpoint descriptions.

- **Chores**
  - Version updated across multiple configuration files from 2.7.0 to 2.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->