### PR TITLE
Update keycloak package version

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.2
 
 info:
   title: Fleet v2 HTTP API
-  version: 2.8.0
+  version: 2.8.1
   description: HTTP-based API for Fleet Protocol v2 serving for communication between the External Server and the end users.
   contact:
     email: jiri.strouhal@bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "server"
-version = "2.8.0"
+version = "2.8.1"
 
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy >= 2.0.23
 psycopg >= 3.1.0
 psycopg-binary
 Flask_Testing==0.8.1
-python-keycloak == 3.7.0
+python-keycloak == 4.7.0
 pyjwt == 2.3.0
 cryptography == 3.4.8
 coverage>=7.3.2

--- a/server/fleetv2_http_api/impl/controllers.py
+++ b/server/fleetv2_http_api/impl/controllers.py
@@ -86,7 +86,7 @@ def login(device: Optional[str] = None) -> WerkzeugResponse | Response | tuple[d
             auth_json = _security.device_get_authentication()
         except Exception as e:
             msg = "Problem reaching oAuth service."
-            _log_debug(e)
+            _log_debug(str(e))
             return _log_info_and_respond(msg, 500, msg)
         return _log_info_and_respond(auth_json, 200, "Device authentication initialized.")
     elif device != None:
@@ -95,13 +95,13 @@ def login(device: Optional[str] = None) -> WerkzeugResponse | Response | tuple[d
             return _log_info_and_respond(token, 200, "Device authenticated, jwt token generated.")
         except Exception as e:
             msg = "Invalid device code or device still authenticating."
-            _log_debug(e)
+            _log_debug(str(e))
             return _log_info_and_respond(msg, 400, msg)
     try:
         return redirect(_security.get_authentication_url())
     except Exception as e:
         msg = "Problem reaching oAuth service."
-        _log_debug(e)
+        _log_debug(str(e))
         return _log_info_and_respond(msg, 500, msg)
 
 

--- a/server/fleetv2_http_api/impl/security.py
+++ b/server/fleetv2_http_api/impl/security.py
@@ -3,7 +3,15 @@ from urllib.parse import urlparse
 
 
 class SecurityObj:
-    def set_config(self, keycloak_url: str, client_id: str, secret_key: str, scope: str, realm: str, base_uri: str) -> None:
+    def set_config(
+        self,
+        keycloak_url: str,
+        client_id: str,
+        secret_key: str,
+        scope: str,
+        realm: str,
+        base_uri: str,
+    ) -> None:
         """Set configuration for keycloak authentication and initialize KeycloakOpenID."""
         self._keycloak_url = keycloak_url
         self._scope = scope
@@ -15,15 +23,13 @@ class SecurityObj:
             server_url=keycloak_url,
             client_id=client_id,
             realm_name=realm,
-            client_secret_key=secret_key
+            client_secret_key=secret_key,
         )
 
     def get_authentication_url(self) -> str:
         """Get keycloak url used for authentication."""
         auth_url = self._oid.auth_url(
-            redirect_uri=self._callback,
-            scope=self._scope,
-            state=self._state
+            redirect_uri=self._callback, scope=self._scope, state=self._state
         )
         return auth_url
 
@@ -41,23 +47,18 @@ class SecurityObj:
             raise Exception("Invalid issuer")
 
         token = self._oid.token(
-            grant_type="authorization_code",
-            code=code,
-            redirect_uri=self._callback
+            grant_type="authorization_code", code=code, redirect_uri=self._callback
         )
         return token
 
     def device_token_get(self, device_code: str) -> dict:
         """Get token from keycloak using a device code returned by keycloak."""
         token = self._oid.token(
-            grant_type="urn:ietf:params:oauth:grant-type:device_code",
-            device_code=device_code
+            grant_type="urn:ietf:params:oauth:grant-type:device_code", device_code=device_code
         )
         return token
 
     def token_refresh(self, refresh_token: str) -> dict:
         """Get a new token from keycloak using the refresh token."""
-        token = self._oid.refresh_token(
-            refresh_token=refresh_token
-        )
+        token = self._oid.refresh_token(refresh_token=refresh_token)
         return token

--- a/server/fleetv2_http_api/openapi/openapi.yaml
+++ b/server/fleetv2_http_api/openapi/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: GPLv3
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: Fleet v2 HTTP API
-  version: 2.8.0
+  version: 2.8.1
 servers:
 - url: /v2/protocol
 security:


### PR DESCRIPTION
python-keycloak v3.7.0 showed missing arguments 'scope' and 'state' in method KeyclocakOpenID.auth_url, contradicting its documentation. This error in the package code occurred seemingly randomly across attempts to reinstall the package. 

In the end, version 3.7.0 has been abandoned and 4.7.0 is used instead. 

Additionaly, a debug message is now logged if any error occurs when calling endpoint /login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated API version from 2.8.0 to 2.8.1, ensuring continued compatibility.
  
- **Bug Fixes**
	- Enhanced error handling and logging across several API functions for improved clarity and consistency.
  
- **Chores**
	- Updated project version in configuration files.
	- Modified dependency version for `python-keycloak` to ensure up-to-date functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->