### PR TITLE
Fix async client proxies argument

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.2
 
 info:
   title: Fleet v2 HTTP API
-  version: 2.8.2
+  version: 2.8.3
   description: HTTP-based API for Fleet Protocol v2 serving for communication between the External Server and the end users.
   contact:
     email: jiri.strouhal@bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "server"
-version = "2.8.2"
+version = "2.8.3"
 
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.1.1
+httpx == 0.27.2
 APScheduler >= 3.10.0
 aenum == 3.1.15
 SQLAlchemy >= 2.0.23

--- a/server/fleetv2_http_api/openapi/openapi.yaml
+++ b/server/fleetv2_http_api/openapi/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: GPLv3
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: Fleet v2 HTTP API
-  version: 2.8.2
+  version: 2.8.3
 servers:
 - url: /v2/protocol
 security:


### PR DESCRIPTION
Keycloak package internally uses the httpx Python package. This package recently had an update, which has not been addressed by the keycloak package, at least not yet.

I added a line to requirements.txt, setting the httpx version to 0.27.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new dependency (`httpx`) for enhanced functionality.
  
- **Bug Fixes**
  - Updated various dependencies to specific versions for improved stability and compatibility.

- **Documentation**
  - Incremented the API version from 2.8.2 to 2.8.3, ensuring users are aware of the latest updates. 

These changes ensure the application remains up-to-date and reliable without altering existing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->