### PR TITLE
Baf 1051/login endpoint fix

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,43 +1,42 @@
 {
-    "logging": {
-        "console": {
-            "level": "info",
-            "use": true
-        },
-        "file": {
-            "level": "info",
-            "use": true,
-            "path": "./log/"
-        }
+  "logging": {
+    "console": {
+      "level": "debug",
+      "use": true
     },
-    "http_server": {
-        "base_uri": "https://test-api.bringautofleet.com/v2/protocol",
-        "port": 8080
-    },
-    "database": {
-        "server": {
-            "location": "localhost",
-            "port": 5432,
-            "username": "postgres",
-            "password": "1234",
-            "database_name": "protocol_api"
-        },
-        "cleanup": {
-            "timing_in_seconds": {
-                "retention_period": 1200,
-                "cleanup_period": 60
-
-            }
-        }
-    },
-    "request_for_messages": {
-        "timeout_in_seconds": 5
-    },
-    "security": {
-        "keycloak_url": "https://keycloak.bringauto.com",
-        "client_id": "",
-        "client_secret_key": "",
-        "scope": "",
-        "realm": ""
+    "file": {
+      "level": "info",
+      "use": true,
+      "path": "./log/"
     }
+  },
+  "http_server": {
+    "base_uri": "https://test-api.bringautofleet.com/v2/protocol",
+    "port": 8080
+  },
+  "database": {
+    "server": {
+      "location": "localhost",
+      "port": 5432,
+      "username": "postgres",
+      "password": "1234",
+      "database_name": "protocol_api"
+    },
+    "cleanup": {
+      "timing_in_seconds": {
+        "retention_period": 1200,
+        "cleanup_period": 60
+      }
+    }
+  },
+  "request_for_messages": {
+    "timeout_in_seconds": 5
+  },
+  "security": {
+    "keycloak_url": "https://keycloak.bringauto.com",
+    "client_id": "",
+    "client_secret_key": "",
+    "scope": "",
+    "realm": ""
+  }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,7 @@
 {
   "logging": {
     "console": {
-      "level": "info",
+      "level": "debug",
       "use": true
     },
     "file": {

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,7 @@
 {
   "logging": {
     "console": {
-      "level": "debug",
+      "level": "info",
       "use": true
     },
     "file": {

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -65,7 +65,7 @@ def _set_up_database_jobs(config: CleanupTiming) -> None:
 def _retrieve_keycloak_public_key(keycloak_url: str, realm: str) -> str:
     """Retrieve the public key from the Keycloak server."""
     try:
-        response = requests.get(keycloak_url + "/realms/" + realm)
+        response = requests.get(keycloak_url.rstrip("/") + "/realms/" + realm)
         response.raise_for_status()
         logger.info("Retrieved public key from Keycloak server.")
         return response.json()["public_key"]

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -1,25 +1,21 @@
 import sys
-
-sys.path.append("server")
 import logging
-import requests  # type: ignore
 import os
 
+sys.path.append("server")
+
+import requests  # type: ignore
 import connexion  # type: ignore
-from fleetv2_http_api import encoder  # type: ignore
 from apscheduler.schedulers.background import BackgroundScheduler  # type: ignore
 
+from .fleetv2_http_api import encoder  # type: ignore
 from .config import CleanupTiming
 from server.database.database_controller import remove_old_messages, set_message_retention_period  # type: ignore
 from server.database.cache import clear_connected_cars  # type: ignore
 from server.database.connection import set_db_connection  # type: ignore
 from server.database.time import timestamp  # type: ignore
-from server.fleetv2_http_api.impl.controllers import (  # type: ignore
-    set_car_wait_timeout_s,
-    set_status_wait_timeout_s,
-    set_command_wait_timeout_s,
-    init_security,
-)
+
+import server.fleetv2_http_api.impl.controllers as api_controllers  # type: ignore
 from server.fleetv2_http_api.controllers.security_controller import set_auth_params  # type: ignore
 import server.database.script_args as script_args  # type: ignore
 from server.logs import configure_logging, LOGGER_NAME
@@ -92,10 +88,10 @@ if __name__ == "__main__":
     configure_logging(COMPONENT_NAME, config)
     _connect_to_database(vals)
     _set_up_database_jobs(config.database.cleanup.timing_in_seconds)
-    set_car_wait_timeout_s(config.request_for_messages.timeout_in_seconds)
-    set_status_wait_timeout_s(config.request_for_messages.timeout_in_seconds)
-    set_command_wait_timeout_s(config.request_for_messages.timeout_in_seconds)
-    init_security(config.security, str(config.http_server.base_uri))
+    api_controllers.set_car_wait_timeout_s(config.request_for_messages.timeout_in_seconds)
+    api_controllers.set_status_wait_timeout_s(config.request_for_messages.timeout_in_seconds)
+    api_controllers.set_command_wait_timeout_s(config.request_for_messages.timeout_in_seconds)
+    api_controllers.init_oauth(config.security, str(config.http_server.base_uri))
     set_auth_params(
         public_key=_retrieve_keycloak_public_key(
             keycloak_url=str(config.security.keycloak_url), realm=config.security.realm

--- a/server/config.py
+++ b/server/config.py
@@ -5,7 +5,7 @@ import json
 
 
 LoggingLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
-from .fleetv2_http_api.impl.security import SecurityConfig as _SecurityConfig
+from .fleetv2_http_api.impl.security import SecurityConfig as SecurityConfig
 
 
 class APIConfig(pydantic.BaseModel):
@@ -13,7 +13,7 @@ class APIConfig(pydantic.BaseModel):
     http_server: HTTPServer
     database: Database
     request_for_messages: MessageRequest
-    security: _SecurityConfig
+    security: SecurityConfig
 
 
 class Logging(pydantic.BaseModel):

--- a/server/database/database_controller.py
+++ b/server/database/database_controller.py
@@ -20,7 +20,7 @@ from server.database.connection import (
     Base,
     get_connection_source as _get_connection_source,
     set_db_connection as _set_db_connection,
-    set_test_db_connection as _set_test_db_connection
+    set_test_db_connection as _set_test_db_connection,
 )
 from server.database.cache import (  # type: ignore
     add_car,
@@ -31,8 +31,6 @@ from server.database.cache import (  # type: ignore
     clear_connected_cars as _clear_connected_cars,
 )
 from server.fleetv2_http_api.models.device_id import DeviceId  # type: ignore
-
-
 from ..logs import LOGGER_NAME
 
 
@@ -75,7 +73,7 @@ class MessageBase(Base):
 
     @staticmethod
     def from_message(
-        company_name: str, car_name: str, message: Message_DB, order: int = 0
+        company_name: str, car_name: str, message: MessageDB, order: int = 0
     ) -> MessageBase:
         return MessageBase(
             timestamp=message.timestamp,
@@ -93,7 +91,7 @@ class MessageBase(Base):
         )
 
     @staticmethod
-    def from_messages(company_name: str, car_name: str, *messages: Message_DB) -> list[MessageBase]:
+    def from_messages(company_name: str, car_name: str, *messages: MessageDB) -> list[MessageBase]:
         bases: list[MessageBase] = list()
         for k in range(len(messages)):
             bases.append(
@@ -101,8 +99,8 @@ class MessageBase(Base):
             )
         return bases
 
-    def to_message(self) -> Message_DB:
-        return Message_DB(
+    def to_message(self) -> MessageDB:
+        return MessageDB(
             timestamp=self.timestamp,
             module_id=self.module_id,
             device_type=self.device_type,
@@ -116,7 +114,7 @@ class MessageBase(Base):
 
 
 @dataclasses.dataclass
-class Message_DB:
+class MessageDB:
     """Object defining the structure of messages sent to and retrieved from the database."""
 
     timestamp: int
@@ -153,7 +151,7 @@ def get_available_devices_from_database() -> None:
 
 
 def send_messages_to_database(
-    company_name: str, car_name: str, *messages: Message_DB
+    company_name: str, car_name: str, *messages: MessageDB
 ) -> tuple[str, int]:
     """Send a list of messages to the database, returns number of succesfully sent messages (int)."""
     try:
@@ -166,7 +164,7 @@ def send_messages_to_database(
     except _IntegrityError:
         return (
             "Some of the messages are identical to those sent previously, including their timestamps.",
-            400
+            400,
         )
     except _DatabaseNotAccessible:
         return "Database not accessible.", 503
@@ -183,7 +181,7 @@ def _get_message_for_n_messages_succesfully_sent(number_of_sent_messages: int) -
 
 def list_messages(
     company_name: str, car_name: str, message_type: tuple[str, ...], since: int = 0
-) -> list[Message_DB]:  # noqa:
+) -> list[MessageDB]:  # noqa:
     """Return a list of messages of the given type, optionally filtered by the given parameters.
     If all is not None, then all messages of the given type are returned.
 
@@ -191,7 +189,7 @@ def list_messages(
     less or equal to since are returned. Otherwise, the newest message is returned.
     """
 
-    statuses: list[Message_DB] = list()
+    statuses: list[MessageDB] = list()
     with Session(_get_connection_source()) as session:
         table = MessageBase.__table__
         selection = select(MessageBase)

--- a/server/fleetv2_http_api/controllers/security_controller.py
+++ b/server/fleetv2_http_api/controllers/security_controller.py
@@ -3,6 +3,7 @@ from typing import Dict
 from server.database.security import get_admin
 import jwt
 
+
 _public_key: str
 _client_id: str
 

--- a/server/fleetv2_http_api/impl/controllers.py
+++ b/server/fleetv2_http_api/impl/controllers.py
@@ -11,7 +11,7 @@ from server.enums import MessageType  # type: ignore
 from server.fleetv2_http_api.models import Payload, DeviceId, Message, Module, Car  # type: ignore
 from server.database.database_controller import (  # type: ignore
     send_messages_to_database,
-    Message_DB,
+    MessageDB,
     cleanup_device_commands_and_warn_before_future_commands,
 )
 from server.database.database_controller import list_messages as _list_messages
@@ -26,15 +26,10 @@ from server.database.cache import (  # type: ignore
 from server.database.time import timestamp as _timestamp  # type: ignore
 from server.fleetv2_http_api.impl.message_wait import MessageWaitObjManager as _MessageWaitObjManager  # type: ignore
 from server.fleetv2_http_api.impl.car_wait import CarWaitObjManager as _CarWaitObjManager  # type: ignore
-from server.fleetv2_http_api.impl.security import (  # type: ignore
-    SecurityObj as _SecurityObj,
-    SecurityObjImpl as _SecurityObjImpl,
-    SecurityConfig as _SecurityConfig,
-    KeycloakClient as _KeycloakClient,
-    empty_security_obj as _empty_security_obj,
-    OAuthAuthenticationNotSet as _OAuthAuthenticationNotSet,
-)
+
+import server.fleetv2_http_api.impl.security as _msecurity  # type: ignore
 from server.logs import LOGGER_NAME as _LOGGER_NAME
+from server.config import SecurityConfig as _SecurityConfig
 
 
 logger = logging.getLogger(_LOGGER_NAME)
@@ -66,43 +61,20 @@ def get_command_wait_timeout_s() -> float:
     return _cmd_wait_manager.timeout_ms * 0.001
 
 
-def init_security(config: Any, base_uri: str) -> None:
+def init_oauth(config: _SecurityConfig, base_uri: str) -> None:
+    """Initialize OAuth with the given configuration and base URI."""
     client = _get_keycloak_openid_client(config)
-    init_security_with_client(config, base_uri, client)
+    _msecurity.init_oauth(config, base_uri, client)
+    if _msecurity.security.is_empty():
+        logger.warning("Keycloak authentication has not been initialized.")
 
 
-def init_security_with_client(config: Any, base_uri: str, client: _KeycloakClient) -> None:
-    global _security
-    _security = _SecurityObjImpl(config, base_uri, client)
-
-    assert _security.is_not_empty(), "Security object is empty after initialization."
-
-    if not _security.is_not_empty():
-        raise RuntimeError("Using empty security object - Keycloak authentication is not set up.")
-    else:
-        logger.debug("Security object initialized")
-
-
-def _get_security() -> _SecurityObj:
-    global _security
-    try:
-        return _security
-    except NameError:
-        _security = _empty_security_obj
-        return _security
-
-
-def deinit_security() -> None:
-    global _security
-    _security = _empty_security_obj
-
-
-def _get_keycloak_openid_client(config: _SecurityConfig) -> KeycloakOpenID:
+def _get_keycloak_openid_client(config: _msecurity.SecurityConfig) -> KeycloakOpenID:
     client = KeycloakOpenID(
-        server_url=config.keycloak_url,
-        client_id=config.client_id,
-        realm_name=config.realm,
-        client_secret_key=config.client_secret_key,
+        server_url=str(config.keycloak_url),
+        client_id=str(config.client_id),
+        realm_name=str(config.realm),
+        client_secret_key=str(config.client_secret_key),
     )
     return client
 
@@ -125,9 +97,9 @@ def login(device: Optional[str] = None) -> WerkzeugResponse | Response | tuple[d
     """
     if device == "":
         try:
-            auth_json = _get_security().device_get_authentication()
+            auth_json = _msecurity.security.device_get_authentication()
             return _log_info_and_respond(auth_json, 200, "Device authentication initialized.")
-        except _OAuthAuthenticationNotSet as e:
+        except _msecurity.UninitializedOAuth as e:
             msg = "Cannot get device authentication. Keycloak authentication is not set on the HTTP API."
             _log_debug(str(e))
             return _log_info_and_respond(msg, 500, msg)
@@ -138,10 +110,10 @@ def login(device: Optional[str] = None) -> WerkzeugResponse | Response | tuple[d
 
     elif device != None:
         try:
-            token = _get_security().device_token_get(device)  # type: ignore
+            token = _msecurity.security.device_token_get(device)  # type: ignore
             return _log_info_and_respond(token, 200, "Device authenticated, jwt token generated.")
-        except _OAuthAuthenticationNotSet as e:
-            msg = "Cannot get device authentication. Keycloak authentication is not set on the HTTP API."
+        except _msecurity.UninitializedOAuth as e:
+            msg = "Cannot get device token. Keycloak authentication is not set on the HTTP API."
             _log_debug(str(e))
             return _log_info_and_respond(msg, 500, msg)
         except Exception as e:
@@ -149,16 +121,14 @@ def login(device: Optional[str] = None) -> WerkzeugResponse | Response | tuple[d
             _log_debug(str(e))
             return _log_info_and_respond(msg, 400, msg)
     try:
-        return redirect(_get_security().get_authentication_url())
-    except _OAuthAuthenticationNotSet as e:
-        msg = (
-            "Cannot get device authentication. Keycloak authentication is not set on the HTTP API."
-        )
+        return redirect(_msecurity.security.get_authentication_url())
+    except _msecurity.UninitializedOAuth as e:
+        msg = "Cannot get authentication URL. Keycloak authentication is not set on the HTTP API."
         _log_debug(str(e))
         return _log_info_and_respond(msg, 500, msg)
     except Exception as e:
         msg = "Problem reaching oAuth service."
-        _log_debug(str(e))
+        _log_debug("(Device is None): " + str(e))
         return _log_info_and_respond(msg, 500, msg)
 
 
@@ -184,9 +154,9 @@ def token_get(
     :rtype: dict
     """
     try:
-        token = _get_security().token_get(state, iss, code)  # type: ignore
+        token = _msecurity.security.token_get(state, iss, code)  # type: ignore
         return _log_info_and_respond(token, 200, "Jwt token generated.")
-    except _OAuthAuthenticationNotSet as e:
+    except _msecurity.UninitializedOAuth as e:
         msg = "Cannot get token. Keycloak authentication is not set on the HTTP API."
         _log_debug(str(e))
         return _log_info_and_respond(msg, 500, msg)
@@ -207,8 +177,8 @@ def token_refresh(refresh_token: str) -> tuple[dict, int]:
     :rtype: dict
     """
     try:
-        token = _get_security().token_refresh(refresh_token)
-    except _OAuthAuthenticationNotSet as e:
+        token = _msecurity.security.token_refresh(refresh_token)
+    except _msecurity.UninitializedOAuth as e:
         msg = "Cannot refresh token. Keycloak authentication is not set on the HTTP API."
         _log_debug(str(e))
         return _log_info_and_respond(msg, 500, msg)
@@ -414,7 +384,7 @@ def send_commands(
         response = _car_availability(company_name, car_name)
         if response[1] != 200:
             return response
-        msg = f"Empty list of commands was sent to the API; no commands were sent to the device."
+        msg = "Empty list of commands was sent to the API; no commands were sent to the device."
         return _log_info_and_respond(msg, 200, msg)
     errors = _check_sent_commands(company_name, car_name, messages)
     if errors[0] != "":
@@ -450,7 +420,7 @@ def send_statuses(
     messages = _message_list_from_request_body(body)
 
     if messages == []:
-        msg = f"Empty list of statuses was sent to the API; no statuses were sent to the device."
+        msg = "Empty list of statuses was sent to the API; no statuses were sent to the device."
         return _log_info_and_respond(msg, 200, msg)
     errors = _check_messages((MessageType.STATUS, MessageType.STATUS_ERROR), *messages)
     if errors[0] != "":
@@ -469,7 +439,7 @@ def send_statuses(
 def _message_list_from_request_body(body: list[dict | Message]) -> list[Message]:
     messages: list[Message] = list()
     for item in body:
-        messages.append(Message.from_dict(item) if type(item) == dict else item)
+        messages.append(Message.from_dict(item) if isinstance(item, dict) else item)
     return messages
 
 
@@ -520,7 +490,7 @@ def _check_messages(expected_message_types: tuple[str, ...], *messages: Message)
 
     errors: str = ""
     errors = _check_message_types(expected_message_types, *messages)
-    if not errors.strip() == "":
+    if errors.strip() != "":
         return errors, 400
     else:
         return "", 200
@@ -586,7 +556,7 @@ def _handle_first_status_and_return_warnings(
     )
 
 
-def _message_from_db(message_db: Message_DB) -> Message:
+def _message_from_db(message_db: MessageDB) -> Message:
     """Convert Message_DB to Message."""
     return Message(
         timestamp=message_db.timestamp,
@@ -604,13 +574,13 @@ def _message_from_db(message_db: Message_DB) -> Message:
     )
 
 
-def _message_db_list(messages: list[Message]) -> list[Message_DB]:
+def _message_db_list(messages: list[Message]) -> list[MessageDB]:
     """Convert list of messages to list of Message_DB."""
     for m in messages:
         if isinstance(m.payload.message_type, MessageType):
             m.payload.message_type = m.payload.message_type.value
     return [
-        Message_DB(
+        MessageDB(
             timestamp=message.timestamp,
             serialized_device_id=_serialized_device_id(message.device_id),
             module_id=message.device_id.module_id,
@@ -656,7 +626,7 @@ def _response_for_request_for_disconnected_cars_commands(
     )
 
 
-def _update_messages_timestamp(messages: Iterable[Message_DB]) -> int:
+def _update_messages_timestamp(messages: Iterable[MessageDB]) -> int:
     timestamp_now = _timestamp()
     for message in messages:
         message.timestamp = timestamp_now

--- a/server/fleetv2_http_api/impl/message_wait.py
+++ b/server/fleetv2_http_api/impl/message_wait.py
@@ -16,9 +16,12 @@ class MessageWaitObjManager:
         self._wait_dict: dict[str, dict[str, list[MessageWaitObj]]] = dict()
 
     @property
-    def timeout_ms(self) -> int: return self._timeout_ms
+    def timeout_ms(self) -> int:
+        return self._timeout_ms
 
-    def add_response_content_and_stop_waiting(self, company: str, car: str, reponse_content: list[Message]) -> None:
+    def add_response_content_and_stop_waiting(
+        self, company: str, car: str, reponse_content: list[Message]
+    ) -> None:
         """Make the next wait object in the queue to respond with specified 'reponse_content' and remove it from the queue."""
         wait_objs = self._get_wait_objects_for_given_car(company, car)
         if wait_objs:
@@ -29,9 +32,9 @@ class MessageWaitObjManager:
         """Create a new wait object and adds it to the wait queue for given company and car."""
         wait_obj = MessageWaitObj(company, car_name, self._timeout_ms)
 
-        if not company in self._wait_dict:
+        if company not in self._wait_dict:
             self._wait_dict[company] = dict()
-        if not car_name in self._wait_dict[company]:
+        if car_name not in self._wait_dict[company]:
             self._wait_dict[company][car_name] = list()
 
         self._wait_dict[company][car_name].append(wait_obj)
@@ -66,14 +69,15 @@ class MessageWaitObjManager:
 
         return msgs
 
-    def _send_content_to_all_wait_objs(self, wait_objs: list[MessageWaitObj], reponse_content: list[Message]) -> None:
+    def _send_content_to_all_wait_objs(
+        self, wait_objs: list[MessageWaitObj], reponse_content: list[Message]
+    ) -> None:
         for wait_obj in wait_objs:
             wait_obj.add_reponse_content_and_stop_waiting(reponse_content)
 
     def _get_wait_objects_for_given_car(self, company: str, car: str) -> list[MessageWaitObj]:
-        if company in self._wait_dict:
-            if car in self._wait_dict[company]:
-                return self._wait_dict[company][car]
+        if company in self._wait_dict and car in self._wait_dict[company]:
+            return self._wait_dict[company][car]
         return list()
 
     def _remove_wait_obj_list(self, company: str, car: str) -> None:
@@ -96,9 +100,12 @@ class MessageWaitObj:
         self._condition = threading.Condition()
 
     @property
-    def company(self) -> str: return self._company
+    def company(self) -> str:
+        return self._company
+
     @property
-    def car_name(self) -> str: return self._car_name
+    def car_name(self) -> str:
+        return self._car_name
 
     def add_reponse_content_and_stop_waiting(self, content: list[Message]) -> None:
         self._response_content = content.copy()
@@ -108,10 +115,10 @@ class MessageWaitObj:
     def wait_and_get_response(self) -> list[Message]:
         """Wait for the response object to be set and then return it."""
         with self._condition:
-            self._condition.wait(timeout=self._timeout_ms/1000)
+            self._condition.wait(timeout=self._timeout_ms / 1000)
         return self._response_content
 
     @staticmethod
     def timestamp() -> int:
         """Unix timestamp in milliseconds."""
-        return int(time.time()*1000)
+        return int(time.time() * 1000)

--- a/server/fleetv2_http_api/impl/security.py
+++ b/server/fleetv2_http_api/impl/security.py
@@ -198,6 +198,6 @@ def init_oauth(config: Any, base_uri: str, client: KeycloakClient) -> None:
         raise RuntimeError("Security object is empty after initialization.")
 
 
-def deinit_security() -> None:
+def deinit_oauth() -> None:
     global security
     security = _empty_security_obj

--- a/server/fleetv2_http_api/impl/security.py
+++ b/server/fleetv2_http_api/impl/security.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 import abc
-from typing import Protocol
-from urllib.parse import urlparse
+from typing import Protocol, Any
 import uuid
 
+from urllib.parse import urlparse
 import pydantic
 
 
@@ -70,9 +70,9 @@ class SecurityObj(abc.ABC):
     def token_refresh(self, refresh_token: str) -> dict:
         pass
 
-    def is_not_empty(self) -> bool:
+    def is_empty(self) -> bool:
         """Check if the security object is not empty and has all keycloak authentication information."""
-        return self is not empty_security_obj
+        return self is _empty_security_obj
 
 
 class SecurityObjEmpty(SecurityObj):
@@ -82,38 +82,38 @@ class SecurityObjEmpty(SecurityObj):
         pass
 
     def get_authentication_url(self) -> str:
-        raise OAuthAuthenticationNotSet(
+        raise UninitializedOAuth(
             "Cannot get authentication URL. Keycloak authentication is not set. Security object is empty."
         )
 
     def device_get_authentication(self) -> dict:
-        raise OAuthAuthenticationNotSet(
+        raise UninitializedOAuth(
             "Cannot get device authentication. Keycloak authentication is not set.  Security object is empty."
         )
 
     def token_get(self, state: str, iss: str, code: str) -> dict:
-        raise OAuthAuthenticationNotSet(
+        raise UninitializedOAuth(
             "Cannot get token. Keycloak authentication is not set.  Security object is empty.",
         )
 
     def device_token_get(self, device_code: str) -> dict:
-        raise OAuthAuthenticationNotSet(
+        raise UninitializedOAuth(
             "Cannot get device token. Keycloak authentication is not set.  Security object is empty."
         )
 
     def token_refresh(self, refresh_token: str) -> dict:
-        raise OAuthAuthenticationNotSet(
+        raise UninitializedOAuth(
             "Cannot refresh token. Keycloak authentication is not set.  Security object is empty."
         )
 
 
-class OAuthAuthenticationNotSet(Exception):
+class UninitializedOAuth(Exception):
     pass
 
 
-empty_security_obj = SecurityObjEmpty(
+_empty_security_obj = SecurityObjEmpty(
     config=SecurityConfig(
-        keycloak_url="https://empty",
+        keycloak_url=pydantic.AnyUrl("https://empty.com"),
         scope="",
         client_id="",
         client_secret_key="",
@@ -130,10 +130,10 @@ class SecurityObjImpl(SecurityObj):
     ) -> None:
         """Set configuration for keycloak authentication and initialize KeycloakOpenID."""
 
-        self._keycloak_url = config.keycloak_url
+        self._keycloak_url = str(config.keycloak_url)
         self._scope = config.scope
         self._realm_name = config.realm
-        self._callback = base_uri + "/token_get"
+        self._callback = str(base_uri) + "/token_get"
         self._state = uuid.uuid4().hex
         self._client = keycloak_client
 
@@ -186,3 +186,18 @@ class SecurityObjImpl(SecurityObj):
     def issuer_url(issuer: str) -> str:
         """Parse issuer URL from keycloak configuration."""
         return urlparse(issuer).geturl()
+
+
+security: SecurityObj = _empty_security_obj
+
+
+def init_oauth(config: Any, base_uri: str, client: KeycloakClient) -> None:
+    global security
+    security = SecurityObjImpl(config, base_uri, client)
+    if security.is_empty():
+        raise RuntimeError("Security object is empty after initialization.")
+
+
+def deinit_security() -> None:
+    global security
+    security = _empty_security_obj

--- a/server/fleetv2_http_api/impl/security.py
+++ b/server/fleetv2_http_api/impl/security.py
@@ -39,6 +39,11 @@ class SecurityConfig(pydantic.BaseModel):
 class SecurityObj(abc.ABC):
     """Class for handling keycloak authentication."""
 
+    @classmethod
+    def is_defined(cls) -> bool:
+        """Check if the security object is defined."""
+        return hasattr(cls, "instance")
+
     @abc.abstractmethod
     def __init__(
         self, config: SecurityConfig, base_uri: str, openid_client: KeycloakClient
@@ -78,26 +83,28 @@ class SecurityObjEmpty(SecurityObj):
 
     def get_authentication_url(self) -> str:
         raise OAuthAuthenticationNotSet(
-            "Cannot get authentication URL. Keycloak authentication is not set"
+            "Cannot get authentication URL. Keycloak authentication is not set. Security object is empty."
         )
 
     def device_get_authentication(self) -> dict:
         raise OAuthAuthenticationNotSet(
-            "Cannot get device authentication. Keycloak authentication is not set"
+            "Cannot get device authentication. Keycloak authentication is not set.  Security object is empty."
         )
 
     def token_get(self, state: str, iss: str, code: str) -> dict:
         raise OAuthAuthenticationNotSet(
-            "Cannot get token. Keycloak authentication is not set",
+            "Cannot get token. Keycloak authentication is not set.  Security object is empty.",
         )
 
     def device_token_get(self, device_code: str) -> dict:
         raise OAuthAuthenticationNotSet(
-            "Cannot get device token. Keycloak authentication is not set"
+            "Cannot get device token. Keycloak authentication is not set.  Security object is empty."
         )
 
     def token_refresh(self, refresh_token: str) -> dict:
-        raise OAuthAuthenticationNotSet("Cannot refresh token. Keycloak authentication is not set")
+        raise OAuthAuthenticationNotSet(
+            "Cannot refresh token. Keycloak authentication is not set.  Security object is empty."
+        )
 
 
 class OAuthAuthenticationNotSet(Exception):

--- a/tests/authentication/test_oauth_authentication.py
+++ b/tests/authentication/test_oauth_authentication.py
@@ -6,8 +6,8 @@ sys.path.append(".")
 from server.fleetv2_http_api.impl.security import (
     SecurityConfig,
     SecurityObjImpl,
-    empty_security_obj,
-    OAuthAuthenticationNotSet,
+    _empty_security_obj,
+    UninitializedOAuth,
     GetTokenStateMismatch,
     GetTokenIssuerMismatch,
 )
@@ -77,14 +77,14 @@ class Test_Security_Obj(unittest.TestCase):
         )
 
     def test_security_obj_empty_raises_exception(self):
-        with self.assertRaises(OAuthAuthenticationNotSet):
-            empty_security_obj.get_authentication_url()
-        with self.assertRaises(OAuthAuthenticationNotSet):
-            empty_security_obj.device_get_authentication()
-        with self.assertRaises(OAuthAuthenticationNotSet):
-            empty_security_obj.token_get("", "", "")
-        with self.assertRaises(OAuthAuthenticationNotSet):
-            empty_security_obj.device_token_get("")
+        with self.assertRaises(UninitializedOAuth):
+            _empty_security_obj.get_authentication_url()
+        with self.assertRaises(UninitializedOAuth):
+            _empty_security_obj.device_get_authentication()
+        with self.assertRaises(UninitializedOAuth):
+            _empty_security_obj.token_get("", "", "")
+        with self.assertRaises(UninitializedOAuth):
+            _empty_security_obj.device_token_get("")
 
     def test_authentication_url(self) -> None:
         security_obj = SecurityObjImpl(self.config, "https://somebasicuri", self.client_test)

--- a/tests/authentication/test_oauth_authentication.py
+++ b/tests/authentication/test_oauth_authentication.py
@@ -7,15 +7,13 @@ from server.fleetv2_http_api.impl.security import (
     SecurityConfig,
     SecurityObjImpl,
     _empty_security_obj,
+    init_oauth,
+    deinit_oauth,
     UninitializedOAuth,
     GetTokenStateMismatch,
     GetTokenIssuerMismatch,
 )
-from server.fleetv2_http_api.impl.controllers import (
-    init_security_with_client,
-    login,
-    deinit_security,
-)
+from server.fleetv2_http_api.impl.controllers import login
 
 
 TEST_TOKEN_HEADER = {"alg": "RS256", "typ": "JWT", "kid": "test"}
@@ -122,7 +120,7 @@ class Test_Security_Endpoints(unittest.TestCase):
             realm="test",
             client_secret_key="test",
         )
-        deinit_security()
+        deinit_oauth()
 
     def test_calling_login_without_initializing_security_yields_500_error(self):
         response = login()
@@ -133,12 +131,12 @@ class Test_Security_Endpoints(unittest.TestCase):
         self.assertEqual(response[1], 500)
 
     def test_calling_login_after_initializing_security_yields_302_code(self):
-        init_security_with_client(self.config, "https://somebasicuri", self.client_test)
+        init_oauth(self.config, "https://somebasicuri", self.client_test)
         response = login()
         self.assertEqual(response.status_code, 302)
 
     def test_calling_login_after_initializing_security_with_device_yields_302_code(self):
-        init_security_with_client(self.config, "https://somebasicuri", self.client_test)
+        init_oauth(self.config, "https://somebasicuri", self.client_test)
         response = login("some_device")
         self.assertEqual(response[1], 200)
 

--- a/tests/database/test_database_controller.py
+++ b/tests/database/test_database_controller.py
@@ -21,7 +21,7 @@ from server.database.database_controller import (
     list_messages,
     cleanup_device_commands_and_warn_before_future_commands,
     remove_old_messages,
-    Message_DB,
+    MessageDB,
     MessageBase,
 )
 from tests._utils.logs import clear_logs
@@ -34,7 +34,7 @@ class Test_Creating_And_Reading_MessageBase_Objects(unittest.TestCase):
         car_name = "test_car"
         device_id = DeviceId(module_id=45, type=2, role="role1", name="device1")
         sdevice_id = serialized_device_id(device_id)
-        message_db = Message_DB(
+        message_db = MessageDB(
             timestamp=100,
             serialized_device_id=sdevice_id,
             module_id=device_id.module_id,
@@ -110,7 +110,7 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
         device_id_2 = DeviceId(module_id=45, type=2, role="role1", name="device2")
         sdevice_id_2 = serialized_device_id(device_id_1)
 
-        message1 = Message_DB(
+        message1 = MessageDB(
             timestamp=1,
             serialized_device_id=sdevice_id_1,
             module_id=device_id_1.module_id,
@@ -121,7 +121,7 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
             payload_encoding=EncodingType.BASE64,
             payload_data={"key1": "value1"},
         )
-        message2 = Message_DB(
+        message2 = MessageDB(
             timestamp=7,
             serialized_device_id=sdevice_id_2,
             module_id=device_id_2.module_id,
@@ -156,7 +156,7 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
         send_messages_to_database(
             "test_company",
             "test_car",
-            Message_DB(
+            MessageDB(
                 timestamp=0,
                 serialized_device_id=sdevice_id,
                 module_id=device_id.module_id,
@@ -172,7 +172,7 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
         send_messages_to_database(
             "test_company",
             "test_car",
-            Message_DB(
+            MessageDB(
                 timestamp=MessageBase.data_retention_period_ms() + 100,
                 serialized_device_id=sdevice_id,
                 module_id=device_id.module_id,
@@ -188,7 +188,7 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
         send_messages_to_database(
             "test_company",
             "test_car",
-            Message_DB(
+            MessageDB(
                 timestamp=MessageBase.data_retention_period_ms() + 150,
                 serialized_device_id=sdevice_id,
                 module_id=device_id.module_id,
@@ -212,9 +212,7 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
         self.assertEqual(len(warnings), 2)
         # Check that the device commands were cleaned up
         messages = list_messages(
-            company_name="test_company",
-            car_name="test_car",
-            message_type=(MessageType.COMMAND,)
+            company_name="test_company", car_name="test_car", message_type=(MessageType.COMMAND,)
         )
         self.assertEqual(len(messages), 0)
 
@@ -222,7 +220,7 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
     def test_remove_old_messages(self, mock_time_in_ms: Mock):
         device_id = DeviceId(module_id=45, type=2, role="role1", name="device1")
         sdevice_id = serialized_device_id(device_id)
-        message1 = Message_DB(
+        message1 = MessageDB(
             timestamp=0,
             serialized_device_id=sdevice_id,
             module_id=device_id.module_id,
@@ -233,7 +231,7 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
             payload_encoding=EncodingType.JSON,
             payload_data={"key1": "value1"},
         )
-        message2 = Message_DB(
+        message2 = MessageDB(
             timestamp=50,
             serialized_device_id=sdevice_id,
             module_id=device_id.module_id,
@@ -255,9 +253,7 @@ class Test_Sending_And_Clearing_Messages(unittest.TestCase):
 
         # Check that the old messages were removed from the database
         messages = list_messages(
-            company_name="company1",
-            car_name="car1",
-            message_type=(MessageType.STATUS,)
+            company_name="company1", car_name="car1", message_type=(MessageType.STATUS,)
         )
         self.assertEqual(len(messages), 1)
 
@@ -295,7 +291,7 @@ class Test_Send_And_Read_Message(unittest.TestCase):
         device_id = DeviceId(module_id=45, type=2, role="role1", name="device1")
         sdevice_id = serialized_device_id(device_id)
 
-        message_1 = Message_DB(
+        message_1 = MessageDB(
             timestamp=100,
             serialized_device_id=sdevice_id,
             module_id=device_id.module_id,
@@ -306,7 +302,7 @@ class Test_Send_And_Read_Message(unittest.TestCase):
             payload_encoding=EncodingType.BASE64,
             payload_data={"content": "..."},
         )
-        message_2 = Message_DB(
+        message_2 = MessageDB(
             timestamp=150,
             serialized_device_id=sdevice_id,
             module_id=device_id.module_id,
@@ -326,14 +322,10 @@ class Test_Send_And_Read_Message(unittest.TestCase):
         read_messages = list_messages("test_company", "test_car", (MessageType.STATUS,))
         self.assertEqual(len(read_messages), 2)
         # read only the last status
-        read_messages = list_messages(
-            "test_company", "test_car", (MessageType.STATUS,), since=150
-        )
+        read_messages = list_messages("test_company", "test_car", (MessageType.STATUS,), since=150)
         self.assertEqual(len(read_messages), 1)
         # read only statuses after timestamp 120
-        read_messages = list_messages(
-            "test_company", "test_car", (MessageType.STATUS,), since=120
-        )
+        read_messages = list_messages("test_company", "test_car", (MessageType.STATUS,), since=120)
         self.assertEqual(len(read_messages), 1)
         self.assertEqual(read_messages[0].timestamp, 150)
 


### PR DESCRIPTION
There has been an error related to global variable _security in the impl.controllers.py module. 

Thanks to the contents of __main__.py and  all the imports inside the custom modules of the http api, what happened was, that the __main__.py first called init_security, which set the **_security** to some instance of SecurityObjImpl. Then, due to some import of the ...impl.controllers module elsewhere, the **_security** has been reset to empty_security_obj. 

The _security is now set to empty only on demand or when first accessed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
  - Improved configuration file formatting for enhanced readability.
- **Bug Fixes**
  - Fixed URL construction issues to prevent double slashes, ensuring smoother connectivity.
- **Refactor**
  - Enhanced security handling with streamlined initialization and clearer error messaging for a more robust experience.
  - Renamed message-related classes for consistency across the codebase.
  - Adjusted method signatures and return types for clarity and consistency.
- **New Features**
  - Introduced global variables for public key and client ID in the security controller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->