### PR TITLE
Fix JWT token issuer validation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.2
 
 info:
   title: Fleet v2 HTTP API
-  version: 2.8.3
+  version: 2.8.5
   description: HTTP-based API for Fleet Protocol v2 serving for communication between the External Server and the end users.
   contact:
     email: jiri.strouhal@bringauto.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "server"
-version = "2.8.3"
+version = "2.8.5"
 
 
 [tool.setuptools.packages.find]

--- a/server/fleetv2_http_api/impl/security.py
+++ b/server/fleetv2_http_api/impl/security.py
@@ -180,7 +180,7 @@ class SecurityObjImpl(SecurityObj):
 
     def _expected_issuer(self) -> str:
         """Get expected issuer URL."""
-        return self.issuer_url(str(self._keycloak_url) + "/realms/" + self._realm_name)
+        return self.issuer_url(str(self._keycloak_url).rstrip("/") + "/realms/" + self._realm_name)
 
     @staticmethod
     def issuer_url(issuer: str) -> str:

--- a/server/fleetv2_http_api/openapi/openapi.yaml
+++ b/server/fleetv2_http_api/openapi/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: GPLv3
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: Fleet v2 HTTP API
-  version: 2.8.3
+  version: 2.8.5
 servers:
 - url: /v2/protocol
 security:

--- a/tests/authentication/test_oauth_authentication.py
+++ b/tests/authentication/test_oauth_authentication.py
@@ -104,7 +104,7 @@ class Test_Security_Obj(unittest.TestCase):
 
     def test_getting_token_with_matching_state_and_issuer_returns_token(self) -> None:
         security_obj = SecurityObjImpl(self.config, "https://somebasicuri", self.client_test)
-        expected_issuer = str(self.config.keycloak_url) + "/realms/" + str(self.config.realm)
+        expected_issuer = str(self.config.keycloak_url).rstrip("/") + "/realms/" + str(self.config.realm)
         token = security_obj.token_get(security_obj._state, expected_issuer, "")
         self.assertIsNotNone(token)
 


### PR DESCRIPTION
Pydantic by default adds a trailing "/" to AnyUrl objects when its a base url with no path.
When validating the issuer, the expected string then didn't match the one provided by keycloak.